### PR TITLE
Enrich discovered models with model info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Originally inspired by [opencode-lmstudio](https://github.com/nicktasios/opencod
 - **Auto-Injection**: Automatically adds unconfigured models into OpenCode provider config
 - **Provider Filtering**: Include or exclude specific providers from discovery
 - **Model Filtering**: Use regex rules to precisely control which discovered models are injected
+- **Model Metadata Enrichment**: Optionally read LiteLLM-style model metadata to populate context limits and reasoning variants
+- **Non-Chat Filtering**: Optionally skip models reported as non-chat by provider metadata, such as embeddings or image generation
 - **Configurable Discovery**: Control discovery behavior with global and provider-level enable/disable switches
 - **Smart Model Formatting**: Optional human-friendly display names for discovered models
 - **Organization Owner Extraction**: Extracts and sets `organizationOwner` from model IDs when available
@@ -102,6 +104,8 @@ Each provider can override discovery behavior through `provider.<name>.options.m
 |--------|------|-------------|
 | `provider.<name>.options.modelsDiscovery.enabled` | `boolean` | Override global discovery and provider filters for a single provider |
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
+| `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Optional LiteLLM-style model info endpoint used to enrich discovered models, for example `/v1/model/info` |
+| `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat` |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Provider-specific model include filter |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Provider-specific model exclude filter |
 | `provider.<name>.options.modelsDiscovery.smartModelName` | `boolean` | Override global `smartModelName` for a single provider |
@@ -120,6 +124,39 @@ Priority rules:
 2. If a provider defines its own `modelsDiscovery.models` filters, those filters replace global `models.includeRegex/excludeRegex` for that provider
 3. If a provider does not define its own model filters, global `models.includeRegex/excludeRegex` are used
 4. `provider.<name>.options.modelsDiscovery.smartModelName` overrides global `smartModelName`
+
+#### LiteLLM Metadata Enrichment
+
+LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-compatible `/v1/models` endpoint. Configure `modelInfoEndpoint` to use that metadata for discovered models:
+
+```json
+{
+  "plugin": ["opencode-models-discovery"],
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": {
+        "baseURL": "http://127.0.0.1:4000/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "endpoint": "/v1/models",
+          "modelInfoEndpoint": "/v1/model/info",
+          "filterNonChat": true
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+When `modelInfoEndpoint` is configured, the plugin uses fields from each LiteLLM `model_info` object to populate OpenCode model configuration:
+
+- `max_input_tokens`, `max_output_tokens`, and `max_tokens` become `limit.context`, `limit.input`, and `limit.output`
+- `supports_reasoning` enables `reasoning`
+- `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`
+- With `filterNonChat: true`, entries whose `model_info.mode` is not `chat` are skipped
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Originally inspired by [opencode-lmstudio](https://github.com/nicktasios/opencod
 - **Auto-Injection**: Automatically adds unconfigured models into OpenCode provider config
 - **Provider Filtering**: Include or exclude specific providers from discovery
 - **Model Filtering**: Use regex rules to precisely control which discovered models are injected
-- **Model Metadata Enrichment**: Optionally read LiteLLM-style model metadata to populate context limits and reasoning variants
-- **Non-Chat Filtering**: Optionally skip models reported as non-chat by provider metadata, such as embeddings or image generation
+- **Model Metadata Enrichment**: Reads LiteLLM-style model metadata by default to populate context limits and reasoning variants
+- **Non-Chat Filtering**: Skips models reported as non-chat by provider metadata, such as embeddings or image generation
 - **Configurable Discovery**: Control discovery behavior with global and provider-level enable/disable switches
 - **Smart Model Formatting**: Optional human-friendly display names for discovered models
 - **Organization Owner Extraction**: Extracts and sets `organizationOwner` from model IDs when available
@@ -104,8 +104,8 @@ Each provider can override discovery behavior through `provider.<name>.options.m
 |--------|------|-------------|
 | `provider.<name>.options.modelsDiscovery.enabled` | `boolean` | Override global discovery and provider filters for a single provider |
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
-| `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Optional LiteLLM-style model info endpoint used to enrich discovered models, for example `/v1/model/info` |
-| `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat` |
+| `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Provider-specific model info endpoint path. Defaults to `/v1/model/info`; set to an empty string to disable metadata enrichment |
+| `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true`; set to `false` to keep all discovered models |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Provider-specific model include filter |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Provider-specific model exclude filter |
 | `provider.<name>.options.modelsDiscovery.smartModelName` | `boolean` | Override global `smartModelName` for a single provider |
@@ -125,9 +125,9 @@ Priority rules:
 3. If a provider does not define its own model filters, global `models.includeRegex/excludeRegex` are used
 4. `provider.<name>.options.modelsDiscovery.smartModelName` overrides global `smartModelName`
 
-#### LiteLLM Metadata Enrichment
+#### Model Metadata Enrichment
 
-LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-compatible `/v1/models` endpoint. Configure `modelInfoEndpoint` to use that metadata for discovered models:
+LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-compatible `/v1/models` endpoint. The plugin queries `/v1/model/info` by default and uses that metadata when the provider supports it. Providers with unusual endpoint paths can override `modelInfoEndpoint`; providers that do not support metadata can disable it with an empty string.
 
 ```json
 {
@@ -140,9 +140,7 @@ LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-com
         "baseURL": "http://127.0.0.1:4000/v1",
         "modelsDiscovery": {
           "enabled": true,
-          "endpoint": "/v1/models",
-          "modelInfoEndpoint": "/v1/model/info",
-          "filterNonChat": true
+          "endpoint": "/v1/models"
         }
       },
       "models": {}
@@ -151,12 +149,31 @@ LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-com
 }
 ```
 
-When `modelInfoEndpoint` is configured, the plugin uses fields from each LiteLLM `model_info` object to populate OpenCode model configuration:
+When model info is available, the plugin uses fields from each LiteLLM `model_info` object to populate OpenCode model configuration:
 
 - `max_input_tokens`, `max_output_tokens`, and `max_tokens` become `limit.context`, `limit.input`, and `limit.output`
 - `supports_reasoning` enables `reasoning`
 - `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`
-- With `filterNonChat: true`, entries whose `model_info.mode` is not `chat` are skipped
+- By default, entries whose `model_info.mode` is not `chat` are skipped
+
+For providers with custom metadata paths or non-standard behavior:
+
+```json
+{
+  "provider": {
+    "custom": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://127.0.0.1:9000/v1",
+        "modelsDiscovery": {
+          "modelInfoEndpoint": "/custom/model-info",
+          "filterNonChat": false
+        }
+      }
+    }
+  }
+}
+```
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Originally inspired by [opencode-lmstudio](https://github.com/nicktasios/opencod
 - **Auto-Injection**: Automatically adds unconfigured models into OpenCode provider config
 - **Provider Filtering**: Include or exclude specific providers from discovery
 - **Model Filtering**: Use regex rules to precisely control which discovered models are injected
-- **Model Metadata Enrichment**: Reads LiteLLM-style model metadata by default to populate context limits and reasoning variants
+- **Model Metadata Enrichment**: Optionally reads provider-specific model metadata to populate context limits and reasoning variants
 - **Non-Chat Filtering**: Skips models reported as non-chat by provider metadata, such as embeddings or image generation
 - **Configurable Discovery**: Control discovery behavior with global and provider-level enable/disable switches
 - **Smart Model Formatting**: Optional human-friendly display names for discovered models
@@ -104,7 +104,8 @@ Each provider can override discovery behavior through `provider.<name>.options.m
 |--------|------|-------------|
 | `provider.<name>.options.modelsDiscovery.enabled` | `boolean` | Override global discovery and provider filters for a single provider |
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
-| `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Provider-specific model info endpoint path. Defaults to `/v1/model/info`; set to an empty string to disable metadata enrichment |
+| `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Provider-specific model info endpoint path. Metadata enrichment is disabled when omitted |
+| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format used to parse and inject metadata. Currently supports `"litellm"` |
 | `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true`; set to `false` to keep all discovered models |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Provider-specific model include filter |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Provider-specific model exclude filter |
@@ -127,7 +128,7 @@ Priority rules:
 
 #### Model Metadata Enrichment
 
-LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-compatible `/v1/models` endpoint. The plugin queries `/v1/model/info` by default and uses that metadata when the provider supports it. Providers with unusual endpoint paths can override `modelInfoEndpoint`; providers that do not support metadata can disable it with an empty string.
+LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-compatible `/v1/models` endpoint. Because this endpoint is not part of the generic OpenAI-compatible API contract, metadata enrichment is opt-in. Configure both `modelInfoEndpoint` and `modelInfoFormat` to enable it for a provider.
 
 ```json
 {
@@ -140,7 +141,9 @@ LiteLLM exposes a richer `/v1/model/info` endpoint in addition to the OpenAI-com
         "baseURL": "http://127.0.0.1:4000/v1",
         "modelsDiscovery": {
           "enabled": true,
-          "endpoint": "/v1/models"
+          "endpoint": "/v1/models",
+          "modelInfoEndpoint": "/v1/model/info",
+          "modelInfoFormat": "litellm"
         }
       },
       "models": {}
@@ -167,6 +170,7 @@ For providers with custom metadata paths or non-standard behavior:
         "baseURL": "http://127.0.0.1:9000/v1",
         "modelsDiscovery": {
           "modelInfoEndpoint": "/custom/model-info",
+          "modelInfoFormat": "litellm",
           "filterNonChat": false
         }
       }

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -13,6 +13,8 @@ interface DiscoveredProvider {
   models: Record<string, any>
 }
 
+const DEFAULT_MODEL_INFO_ENDPOINT = '/v1/model/info'
+
 function hasUsableNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
 }
@@ -131,8 +133,8 @@ export async function enhanceConfig(
       const p = providerConfig as any
       const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
       const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
-      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint
-      const filterNonChat = providerDiscoveryConfig.filterNonChat === true
+      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_MODEL_INFO_ENDPOINT
+      const filterNonChat = providerDiscoveryConfig.filterNonChat !== false
       const forceDiscoveryEnabled = providerDiscoveryConfig.enabled === true
 
       if (!forceDiscoveryEnabled && !canDiscoverModels(p)) {
@@ -177,7 +179,7 @@ export async function enhanceConfig(
         const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)
         if (modelInfoDiscovery.ok) {
           modelInfoById = buildModelInfoMap(modelInfoDiscovery.entries)
-        } else {
+        } else if (providerDiscoveryConfig.modelInfoEndpoint) {
           logger.warn('Provider model info discovery failed', {
             provider: providerName,
             baseURL,

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -191,7 +191,6 @@ export async function enhanceConfig(
       const existingModels = p.models || {}
       const discoveredModels: Record<string, any> = {}
       let chatModelsCount = 0
-      let embeddingModelsCount = 0
 
       const hasProviderModelRegexFilter = !!providerDiscoveryConfig.models?.includeRegex?.length || !!providerDiscoveryConfig.models?.excludeRegex?.length
       const providerModelRegexFilter = getProviderModelRegexFilter(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
@@ -214,6 +213,10 @@ export async function enhanceConfig(
           }
 
           const modelType = categorizeModel(model.id)
+          if (modelType === 'embedding') {
+            continue
+          }
+
           const owner = extractModelOwner(model.id)
           const modelConfig: any = {
             id: model.id,
@@ -224,13 +227,7 @@ export async function enhanceConfig(
             modelConfig.organizationOwner = owner
           }
 
-          if (modelType === 'embedding') {
-            embeddingModelsCount++
-            modelConfig.modalities = {
-              input: ["text"],
-              output: ["embedding"]
-            }
-          } else if (modelType === 'chat') {
+          if (modelType === 'chat') {
             chatModelsCount++
             modelConfig.modalities = {
               input: ["text", "image"],
@@ -255,10 +252,6 @@ export async function enhanceConfig(
           baseURL,
           models: discoveredModels
         })
-
-        if (chatModelsCount === 0 && embeddingModelsCount > 0) {
-          // Provider only has embedding models
-        }
       }
     }
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -1,16 +1,115 @@
 import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
-import { normalizeBaseURL, discoverModelsFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
+import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
-import type { OpenAIModel } from '../types'
+import type { LiteLLMModelInfo, LiteLLMModelInfoEntry, OpenAIModel } from '../types'
 import type { PluginConfig } from '../types/plugin-config'
 
 interface DiscoveredProvider {
   name: string
   baseURL: string
   models: Record<string, any>
+}
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function modelInfoScore(modelId: string, entry: LiteLLMModelInfoEntry): number {
+  const info = entry.model_info ?? {}
+  const modelIdLower = modelId.toLowerCase()
+  let score = 0
+  if (entry.model_name === modelId) score += 8
+  if (info.key === modelId) score += 6
+  if (entry.litellm_params?.model === modelId) score += 4
+  if (entry.litellm_params?.model?.endsWith(`/${modelId}`)) score += 2
+  if (entry.model_name?.toLowerCase() === modelIdLower) score += 3
+  if (info.key?.toLowerCase() === modelIdLower) score += 2
+  if (entry.litellm_params?.model?.toLowerCase() === modelIdLower) score += 2
+  if (entry.litellm_params?.model?.toLowerCase().endsWith(`/${modelIdLower}`)) score += 1
+  if (info.mode === 'chat') score += 5
+  if (hasUsableNumber(info.max_input_tokens) || hasUsableNumber(info.max_tokens)) score += 10
+  if (info.supports_reasoning === true) score += 4
+  return score
+}
+
+function buildModelInfoMap(entries: LiteLLMModelInfoEntry[]): Map<string, LiteLLMModelInfoEntry> {
+  const result = new Map<string, LiteLLMModelInfoEntry>()
+
+  for (const entry of entries) {
+    const keys = new Set<string>()
+    if (entry.model_name) keys.add(entry.model_name)
+    if (entry.model_info?.key) keys.add(entry.model_info.key)
+    if (entry.litellm_params?.model) {
+      keys.add(entry.litellm_params.model)
+      const parts = entry.litellm_params.model.split('/')
+      if (parts.length > 1) keys.add(parts.slice(1).join('/'))
+      keys.add(parts[parts.length - 1])
+    }
+
+    for (const key of keys) {
+      for (const lookupKey of new Set([key, key.toLowerCase()])) {
+        const existing = result.get(lookupKey)
+        if (!existing || modelInfoScore(lookupKey, entry) > modelInfoScore(lookupKey, existing)) {
+          result.set(lookupKey, entry)
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | undefined {
+  if (info.supports_reasoning !== true || !info.supported_openai_params?.includes('reasoning_effort')) {
+    return undefined
+  }
+
+  const variants: Record<string, any> = {}
+  if (info.supports_none_reasoning_effort === true) variants.none = { reasoningEffort: 'none' }
+  if (info.supports_minimal_reasoning_effort === true) variants.minimal = { reasoningEffort: 'minimal' }
+
+  // LiteLLM does not always expose per-tier flags for widely supported efforts.
+  if (info.supports_low_reasoning_effort !== false) variants.low = { reasoningEffort: 'low' }
+  variants.medium = { reasoningEffort: 'medium' }
+  variants.high = { reasoningEffort: 'high' }
+
+  if (info.supports_xhigh_reasoning_effort === true) variants.xhigh = { reasoningEffort: 'xhigh' }
+  if (info.supports_max_reasoning_effort === true) variants.max = { reasoningEffort: 'max' }
+
+  return Object.keys(variants).length > 0 ? variants : undefined
+}
+
+function applyModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
+  const info = entry?.model_info
+  if (!info) return
+
+  const contextLimit = hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : info.max_tokens
+  const outputLimit = hasUsableNumber(info.max_output_tokens) ? info.max_output_tokens : info.max_tokens
+  if (hasUsableNumber(contextLimit) && hasUsableNumber(outputLimit)) {
+    modelConfig.limit = {
+      context: contextLimit,
+      input: hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : undefined,
+      output: outputLimit,
+    }
+  }
+
+  if (info.supports_reasoning === true) {
+    modelConfig.reasoning = true
+  }
+
+  const variants = createReasoningVariants(info)
+  if (variants) {
+    modelConfig.variants = variants
+  }
+}
+
+function shouldSkipForModelInfo(entry: LiteLLMModelInfoEntry | undefined, filterNonChat: boolean): boolean {
+  if (!filterNonChat) return false
+  const mode = entry?.model_info?.mode
+  return typeof mode === 'string' && mode.length > 0 && mode !== 'chat'
 }
 
 export async function enhanceConfig(
@@ -32,6 +131,8 @@ export async function enhanceConfig(
       const p = providerConfig as any
       const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
       const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
+      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint
+      const filterNonChat = providerDiscoveryConfig.filterNonChat === true
       const forceDiscoveryEnabled = providerDiscoveryConfig.enabled === true
 
       if (!forceDiscoveryEnabled && !canDiscoverModels(p)) {
@@ -71,6 +172,20 @@ export async function enhanceConfig(
         continue
       }
 
+      let modelInfoById = new Map<string, LiteLLMModelInfoEntry>()
+      if (typeof modelInfoEndpoint === 'string' && modelInfoEndpoint.length > 0) {
+        const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)
+        if (modelInfoDiscovery.ok) {
+          modelInfoById = buildModelInfoMap(modelInfoDiscovery.entries)
+        } else {
+          logger.warn('Provider model info discovery failed', {
+            provider: providerName,
+            baseURL,
+            endpoint: modelInfoEndpoint,
+          })
+        }
+      }
+
       const existingModels = p.models || {}
       const discoveredModels: Record<string, any> = {}
       let chatModelsCount = 0
@@ -88,6 +203,11 @@ export async function enhanceConfig(
         if (!existingModels[modelKey]) {
           const activeModelRegexFilter = hasProviderModelRegexFilter ? providerModelRegexFilter : modelRegexFilter
           if (!shouldDiscoverModel(model.id, activeModelRegexFilter)) {
+            continue
+          }
+
+          const modelInfo = modelInfoById.get(model.id) ?? modelInfoById.get(model.id.toLowerCase())
+          if (shouldSkipForModelInfo(modelInfo, filterNonChat)) {
             continue
           }
 
@@ -115,6 +235,8 @@ export async function enhanceConfig(
               output: ["text"]
             }
           }
+
+          applyModelInfo(modelConfig, modelInfo)
 
           discoveredModels[modelKey] = modelConfig
         }

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -1,117 +1,17 @@
 import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
+import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
 import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
-import type { LiteLLMModelInfo, LiteLLMModelInfoEntry, OpenAIModel } from '../types'
+import type { OpenAIModel } from '../types'
 import type { PluginConfig } from '../types/plugin-config'
 
 interface DiscoveredProvider {
   name: string
   baseURL: string
   models: Record<string, any>
-}
-
-const DEFAULT_MODEL_INFO_ENDPOINT = '/v1/model/info'
-
-function hasUsableNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0
-}
-
-function modelInfoScore(modelId: string, entry: LiteLLMModelInfoEntry): number {
-  const info = entry.model_info ?? {}
-  const modelIdLower = modelId.toLowerCase()
-  let score = 0
-  if (entry.model_name === modelId) score += 8
-  if (info.key === modelId) score += 6
-  if (entry.litellm_params?.model === modelId) score += 4
-  if (entry.litellm_params?.model?.endsWith(`/${modelId}`)) score += 2
-  if (entry.model_name?.toLowerCase() === modelIdLower) score += 3
-  if (info.key?.toLowerCase() === modelIdLower) score += 2
-  if (entry.litellm_params?.model?.toLowerCase() === modelIdLower) score += 2
-  if (entry.litellm_params?.model?.toLowerCase().endsWith(`/${modelIdLower}`)) score += 1
-  if (info.mode === 'chat') score += 5
-  if (hasUsableNumber(info.max_input_tokens) || hasUsableNumber(info.max_tokens)) score += 10
-  if (info.supports_reasoning === true) score += 4
-  return score
-}
-
-function buildModelInfoMap(entries: LiteLLMModelInfoEntry[]): Map<string, LiteLLMModelInfoEntry> {
-  const result = new Map<string, LiteLLMModelInfoEntry>()
-
-  for (const entry of entries) {
-    const keys = new Set<string>()
-    if (entry.model_name) keys.add(entry.model_name)
-    if (entry.model_info?.key) keys.add(entry.model_info.key)
-    if (entry.litellm_params?.model) {
-      keys.add(entry.litellm_params.model)
-      const parts = entry.litellm_params.model.split('/')
-      if (parts.length > 1) keys.add(parts.slice(1).join('/'))
-      keys.add(parts[parts.length - 1])
-    }
-
-    for (const key of keys) {
-      for (const lookupKey of new Set([key, key.toLowerCase()])) {
-        const existing = result.get(lookupKey)
-        if (!existing || modelInfoScore(lookupKey, entry) > modelInfoScore(lookupKey, existing)) {
-          result.set(lookupKey, entry)
-        }
-      }
-    }
-  }
-
-  return result
-}
-
-function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | undefined {
-  if (info.supports_reasoning !== true || !info.supported_openai_params?.includes('reasoning_effort')) {
-    return undefined
-  }
-
-  const variants: Record<string, any> = {}
-  if (info.supports_none_reasoning_effort === true) variants.none = { reasoningEffort: 'none' }
-  if (info.supports_minimal_reasoning_effort === true) variants.minimal = { reasoningEffort: 'minimal' }
-
-  // LiteLLM does not always expose per-tier flags for widely supported efforts.
-  if (info.supports_low_reasoning_effort !== false) variants.low = { reasoningEffort: 'low' }
-  variants.medium = { reasoningEffort: 'medium' }
-  variants.high = { reasoningEffort: 'high' }
-
-  if (info.supports_xhigh_reasoning_effort === true) variants.xhigh = { reasoningEffort: 'xhigh' }
-  if (info.supports_max_reasoning_effort === true) variants.max = { reasoningEffort: 'max' }
-
-  return Object.keys(variants).length > 0 ? variants : undefined
-}
-
-function applyModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
-  const info = entry?.model_info
-  if (!info) return
-
-  const contextLimit = hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : info.max_tokens
-  const outputLimit = hasUsableNumber(info.max_output_tokens) ? info.max_output_tokens : info.max_tokens
-  if (hasUsableNumber(contextLimit) && hasUsableNumber(outputLimit)) {
-    modelConfig.limit = {
-      context: contextLimit,
-      input: hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : undefined,
-      output: outputLimit,
-    }
-  }
-
-  if (info.supports_reasoning === true) {
-    modelConfig.reasoning = true
-  }
-
-  const variants = createReasoningVariants(info)
-  if (variants) {
-    modelConfig.variants = variants
-  }
-}
-
-function shouldSkipForModelInfo(entry: LiteLLMModelInfoEntry | undefined, filterNonChat: boolean): boolean {
-  if (!filterNonChat) return false
-  const mode = entry?.model_info?.mode
-  return typeof mode === 'string' && mode.length > 0 && mode !== 'chat'
 }
 
 export async function enhanceConfig(
@@ -133,7 +33,8 @@ export async function enhanceConfig(
       const p = providerConfig as any
       const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
       const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
-      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_MODEL_INFO_ENDPOINT
+      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint
+      const modelInfoFormat = providerDiscoveryConfig.modelInfoFormat
       const filterNonChat = providerDiscoveryConfig.filterNonChat !== false
       const forceDiscoveryEnabled = providerDiscoveryConfig.enabled === true
 
@@ -174,16 +75,22 @@ export async function enhanceConfig(
         continue
       }
 
-      let modelInfoById = new Map<string, LiteLLMModelInfoEntry>()
-      if (typeof modelInfoEndpoint === 'string' && modelInfoEndpoint.length > 0) {
+      let modelInfoEnricher: ModelInfoEnricher | undefined
+      if (modelInfoFormat && !isSupportedModelInfoFormat(modelInfoFormat)) {
+        logger.warn('Unsupported provider model info format', {
+          provider: providerName,
+          format: modelInfoFormat,
+        })
+      } else if (typeof modelInfoEndpoint === 'string' && modelInfoEndpoint.length > 0 && modelInfoFormat) {
         const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)
         if (modelInfoDiscovery.ok) {
-          modelInfoById = buildModelInfoMap(modelInfoDiscovery.entries)
-        } else if (providerDiscoveryConfig.modelInfoEndpoint) {
+          modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, modelInfoDiscovery.data, { filterNonChat })
+        } else {
           logger.warn('Provider model info discovery failed', {
             provider: providerName,
             baseURL,
             endpoint: modelInfoEndpoint,
+            format: modelInfoFormat,
           })
         }
       }
@@ -207,8 +114,7 @@ export async function enhanceConfig(
             continue
           }
 
-          const modelInfo = modelInfoById.get(model.id) ?? modelInfoById.get(model.id.toLowerCase())
-          if (shouldSkipForModelInfo(modelInfo, filterNonChat)) {
+          if (modelInfoEnricher?.shouldSkipModel(model.id)) {
             continue
           }
 
@@ -235,7 +141,7 @@ export async function enhanceConfig(
             }
           }
 
-          applyModelInfo(modelConfig, modelInfo)
+          modelInfoEnricher?.applyModelInfo(modelConfig, model.id)
 
           discoveredModels[modelKey] = modelConfig
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,33 @@ export interface OpenAIModelsResponse {
   data: OpenAIModel[]
 }
 
+export interface LiteLLMModelInfo {
+  key?: string | null
+  mode?: string | null
+  max_tokens?: number | null
+  max_input_tokens?: number | null
+  max_output_tokens?: number | null
+  supports_reasoning?: boolean | null
+  supports_none_reasoning_effort?: boolean | null
+  supports_minimal_reasoning_effort?: boolean | null
+  supports_low_reasoning_effort?: boolean | null
+  supports_xhigh_reasoning_effort?: boolean | null
+  supports_max_reasoning_effort?: boolean | null
+  supported_openai_params?: string[] | null
+}
+
+export interface LiteLLMModelInfoEntry {
+  model_name: string
+  litellm_params?: {
+    model?: string
+  }
+  model_info?: LiteLLMModelInfo
+}
+
+export interface LiteLLMModelInfoResponse {
+  data: LiteLLMModelInfoEntry[]
+}
+
 export type ModelType = 'chat' | 'embedding' | 'unknown'
 
 export type LoadingStatus = 'not_loaded' | 'loading' | 'loaded' | 'error'

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -16,6 +16,8 @@ export interface PluginConfig {
 export interface ProviderDiscoveryConfig {
   enabled?: boolean
   endpoint?: string
+  modelInfoEndpoint?: string
+  filterNonChat?: boolean
   models?: {
     includeRegex?: string[]
     excludeRegex?: string[]

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -13,10 +13,13 @@ export interface PluginConfig {
   smartModelName?: boolean
 }
 
+export type ModelInfoFormat = 'litellm' | (string & {})
+
 export interface ProviderDiscoveryConfig {
   enabled?: boolean
   endpoint?: string
   modelInfoEndpoint?: string
+  modelInfoFormat?: ModelInfoFormat
   filterNonChat?: boolean
   models?: {
     includeRegex?: string[]

--- a/src/utils/model-info/index.ts
+++ b/src/utils/model-info/index.ts
@@ -1,0 +1,23 @@
+import { createLiteLLMModelInfoEnricher } from './litellm'
+import type { ModelInfoFormat } from '../../types/plugin-config'
+import type { ModelInfoEnricher, ModelInfoEnricherOptions } from './types'
+
+type ModelInfoEnricherFactory = (data: unknown, options: ModelInfoEnricherOptions) => ModelInfoEnricher
+
+const MODEL_INFO_ENRICHERS: Record<string, ModelInfoEnricherFactory> = {
+  litellm: createLiteLLMModelInfoEnricher,
+}
+
+export function createModelInfoEnricher(
+  format: ModelInfoFormat,
+  data: unknown,
+  options: ModelInfoEnricherOptions
+): ModelInfoEnricher | undefined {
+  return MODEL_INFO_ENRICHERS[format]?.(data, options)
+}
+
+export function isSupportedModelInfoFormat(format: ModelInfoFormat): boolean {
+  return MODEL_INFO_ENRICHERS[format] !== undefined
+}
+
+export type { ModelInfoEnricher, ModelInfoEnricherOptions }

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -1,0 +1,118 @@
+import type { LiteLLMModelInfo, LiteLLMModelInfoEntry } from '../../types'
+import type { ModelInfoEnricher, ModelInfoEnricherOptions } from './types'
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function modelInfoScore(modelId: string, entry: LiteLLMModelInfoEntry): number {
+  const info = entry.model_info ?? {}
+  const modelIdLower = modelId.toLowerCase()
+  let score = 0
+  if (entry.model_name === modelId) score += 8
+  if (info.key === modelId) score += 6
+  if (entry.litellm_params?.model === modelId) score += 4
+  if (entry.litellm_params?.model?.endsWith(`/${modelId}`)) score += 2
+  if (entry.model_name?.toLowerCase() === modelIdLower) score += 3
+  if (info.key?.toLowerCase() === modelIdLower) score += 2
+  if (entry.litellm_params?.model?.toLowerCase() === modelIdLower) score += 2
+  if (entry.litellm_params?.model?.toLowerCase().endsWith(`/${modelIdLower}`)) score += 1
+  if (info.mode === 'chat') score += 5
+  if (hasUsableNumber(info.max_input_tokens) || hasUsableNumber(info.max_tokens)) score += 10
+  if (info.supports_reasoning === true) score += 4
+  return score
+}
+
+function buildModelInfoMap(entries: LiteLLMModelInfoEntry[]): Map<string, LiteLLMModelInfoEntry> {
+  const result = new Map<string, LiteLLMModelInfoEntry>()
+
+  for (const entry of entries) {
+    const keys = new Set<string>()
+    if (entry.model_name) keys.add(entry.model_name)
+    if (entry.model_info?.key) keys.add(entry.model_info.key)
+    if (entry.litellm_params?.model) {
+      keys.add(entry.litellm_params.model)
+      const parts = entry.litellm_params.model.split('/')
+      if (parts.length > 1) keys.add(parts.slice(1).join('/'))
+      keys.add(parts[parts.length - 1])
+    }
+
+    for (const key of keys) {
+      for (const lookupKey of new Set([key, key.toLowerCase()])) {
+        const existing = result.get(lookupKey)
+        if (!existing || modelInfoScore(lookupKey, entry) > modelInfoScore(lookupKey, existing)) {
+          result.set(lookupKey, entry)
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | undefined {
+  if (info.supports_reasoning !== true || !info.supported_openai_params?.includes('reasoning_effort')) {
+    return undefined
+  }
+
+  const variants: Record<string, any> = {}
+  if (info.supports_none_reasoning_effort === true) variants.none = { reasoningEffort: 'none' }
+  if (info.supports_minimal_reasoning_effort === true) variants.minimal = { reasoningEffort: 'minimal' }
+
+  // LiteLLM does not always expose per-tier flags for widely supported efforts.
+  if (info.supports_low_reasoning_effort !== false) variants.low = { reasoningEffort: 'low' }
+  variants.medium = { reasoningEffort: 'medium' }
+  variants.high = { reasoningEffort: 'high' }
+
+  if (info.supports_xhigh_reasoning_effort === true) variants.xhigh = { reasoningEffort: 'xhigh' }
+  if (info.supports_max_reasoning_effort === true) variants.max = { reasoningEffort: 'max' }
+
+  return Object.keys(variants).length > 0 ? variants : undefined
+}
+
+function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
+  const info = entry?.model_info
+  if (!info) return
+
+  const contextLimit = hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : info.max_tokens
+  const outputLimit = hasUsableNumber(info.max_output_tokens) ? info.max_output_tokens : info.max_tokens
+  if (hasUsableNumber(contextLimit) && hasUsableNumber(outputLimit)) {
+    modelConfig.limit = {
+      context: contextLimit,
+      input: hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : undefined,
+      output: outputLimit,
+    }
+  }
+
+  if (info.supports_reasoning === true) {
+    modelConfig.reasoning = true
+  }
+
+  const variants = createReasoningVariants(info)
+  if (variants) {
+    modelConfig.variants = variants
+  }
+}
+
+function getModelInfo(modelInfoById: Map<string, LiteLLMModelInfoEntry>, modelId: string): LiteLLMModelInfoEntry | undefined {
+  return modelInfoById.get(modelId) ?? modelInfoById.get(modelId.toLowerCase())
+}
+
+export function createLiteLLMModelInfoEnricher(
+  data: unknown,
+  options: ModelInfoEnricherOptions
+): ModelInfoEnricher {
+  const response = data as { data?: LiteLLMModelInfoEntry[] } | undefined
+  const modelInfoById = buildModelInfoMap(Array.isArray(response?.data) ? response.data : [])
+
+  return {
+    shouldSkipModel(modelId: string): boolean {
+      if (!options.filterNonChat) return false
+      const mode = getModelInfo(modelInfoById, modelId)?.model_info?.mode
+      return typeof mode === 'string' && mode.length > 0 && mode !== 'chat'
+    },
+    applyModelInfo(modelConfig: any, modelId: string): void {
+      applyLiteLLMModelInfo(modelConfig, getModelInfo(modelInfoById, modelId))
+    },
+  }
+}

--- a/src/utils/model-info/types.ts
+++ b/src/utils/model-info/types.ts
@@ -1,0 +1,8 @@
+export interface ModelInfoEnricher {
+  shouldSkipModel(modelId: string): boolean
+  applyModelInfo(modelConfig: any, modelId: string): void
+}
+
+export interface ModelInfoEnricherOptions {
+  filterNonChat: boolean
+}

--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -1,10 +1,15 @@
-import type { OpenAIModel, OpenAIModelsResponse } from '../types'
+import type { LiteLLMModelInfoEntry, LiteLLMModelInfoResponse, OpenAIModel, OpenAIModelsResponse } from '../types'
 
 const OPENAI_COMPATIBLE_MODELS_ENDPOINT = "/v1/models"
 
 export interface ModelsDiscoveryResult {
   ok: boolean
   models: OpenAIModel[]
+}
+
+export interface ModelInfoDiscoveryResult {
+  ok: boolean
+  entries: LiteLLMModelInfoEntry[]
 }
 
 export function normalizeBaseURL(baseURL: string): string {
@@ -50,6 +55,39 @@ export async function discoverModelsFromProvider(
     }
   } catch {
     return { ok: false, models: [] }
+  }
+}
+
+export async function discoverModelInfoFromProvider(
+  baseURL: string,
+  apiKey?: string,
+  endpoint: string = "/v1/model/info"
+): Promise<ModelInfoDiscoveryResult> {
+  try {
+    const url = buildAPIURL(baseURL, endpoint)
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`
+    }
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(3000),
+    })
+
+    if (!response.ok) {
+      return { ok: false, entries: [] }
+    }
+
+    const data = (await response.json()) as LiteLLMModelInfoResponse
+    return {
+      ok: true,
+      entries: data.data ?? [],
+    }
+  } catch {
+    return { ok: false, entries: [] }
   }
 }
 

--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -1,4 +1,4 @@
-import type { LiteLLMModelInfoEntry, LiteLLMModelInfoResponse, OpenAIModel, OpenAIModelsResponse } from '../types'
+import type { OpenAIModel, OpenAIModelsResponse } from '../types'
 
 const OPENAI_COMPATIBLE_MODELS_ENDPOINT = "/v1/models"
 
@@ -9,7 +9,7 @@ export interface ModelsDiscoveryResult {
 
 export interface ModelInfoDiscoveryResult {
   ok: boolean
-  entries: LiteLLMModelInfoEntry[]
+  data: unknown
 }
 
 export function normalizeBaseURL(baseURL: string): string {
@@ -78,16 +78,16 @@ export async function discoverModelInfoFromProvider(
     })
 
     if (!response.ok) {
-      return { ok: false, entries: [] }
+      return { ok: false, data: undefined }
     }
 
-    const data = (await response.json()) as LiteLLMModelInfoResponse
+    const data = await response.json()
     return {
       ok: true,
-      entries: data.data ?? [],
+      data,
     }
   } catch {
-    return { ok: false, entries: [] }
+    return { ok: false, data: undefined }
   }
 }
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -145,8 +145,11 @@ describe('ModelDiscovery Plugin', () => {
 
       expect(config.provider?.ollama?.models).toBeDefined()
       expect(Object.keys(config.provider.ollama.models).length).toBe(2)
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/v1/models', expect.objectContaining({
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:11434/v1/models', expect.objectContaining({
+        method: 'GET'
+      }))
+      expect(mockFetch).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:11434/v1/model/info', expect.objectContaining({
         method: 'GET'
       }))
     })
@@ -180,8 +183,11 @@ describe('ModelDiscovery Plugin', () => {
       await pluginHooks.config(config)
 
       expect(config.provider.ollama.models['custom-model']).toBeDefined()
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/models', expect.objectContaining({
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:11434/api/models', expect.objectContaining({
+        method: 'GET'
+      }))
+      expect(mockFetch).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:11434/v1/model/info', expect.objectContaining({
         method: 'GET'
       }))
     })
@@ -252,10 +258,7 @@ describe('ModelDiscovery Plugin', () => {
             name: 'LiteLLM',
             options: {
               baseURL: 'http://127.0.0.1:4000/v1',
-              modelsDiscovery: {
-                modelInfoEndpoint: '/v1/model/info',
-                filterNonChat: true
-              }
+              modelsDiscovery: {}
             },
             models: {}
           }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -186,6 +186,111 @@ describe('ModelDiscovery Plugin', () => {
       }))
     })
 
+    it('should enrich LiteLLM models from model info and filter non-chat modes', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'openai/gpt-5.5', object: 'model', created: 1234567890, owned_by: 'openai' },
+              { id: 'text-embedding-3-small', object: 'model', created: 1234567890, owned_by: 'openai' },
+              { id: 'dall-e-3', object: 'model', created: 1234567890, owned_by: 'openai' }
+            ]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                model_name: 'openai/gpt-5.5',
+                litellm_params: { model: 'ollama/openai/gpt-5.5' },
+                model_info: {
+                  key: 'openai/gpt-5.5',
+                  mode: 'chat'
+                }
+              },
+              {
+                model_name: 'openai/gpt-5.5',
+                litellm_params: { model: 'openai/gpt-5.5' },
+                model_info: {
+                  key: 'gpt-5.5',
+                  mode: 'chat',
+                  max_tokens: 128000,
+                  max_input_tokens: 1050000,
+                  max_output_tokens: 128000,
+                  supports_reasoning: true,
+                  supports_none_reasoning_effort: true,
+                  supports_minimal_reasoning_effort: false,
+                  supports_xhigh_reasoning_effort: true,
+                  supported_openai_params: ['reasoning_effort']
+                }
+              },
+              {
+                model_name: 'TEXT-EMBEDDING-3-SMALL',
+                litellm_params: { model: 'openai/TEXT-EMBEDDING-3-SMALL' },
+                model_info: {
+                  mode: 'embedding',
+                  max_input_tokens: 8191
+                }
+              },
+              {
+                model_name: 'dall-e-3',
+                litellm_params: { model: 'openai/dall-e-3' },
+                model_info: {
+                  mode: 'image_generation'
+                }
+              }
+            ]
+          })
+        })
+
+      const config: any = {
+        provider: {
+          litellm: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LiteLLM',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                modelInfoEndpoint: '/v1/model/info',
+                filterNonChat: true
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET'
+      }))
+      expect(mockFetch).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:4000/v1/model/info', expect.objectContaining({
+        method: 'GET'
+      }))
+      expect(config.provider.litellm.models['openai/gpt-5.5']).toEqual(expect.objectContaining({
+        id: 'openai/gpt-5.5',
+        reasoning: true,
+        limit: {
+          context: 1050000,
+          input: 1050000,
+          output: 128000
+        },
+        variants: {
+          none: { reasoningEffort: 'none' },
+          low: { reasoningEffort: 'low' },
+          medium: { reasoningEffort: 'medium' },
+          high: { reasoningEffort: 'high' },
+          xhigh: { reasoningEffort: 'xhigh' }
+        }
+      }))
+      expect(config.provider.litellm.models['text-embedding-3-small']).toBeUndefined()
+      expect(config.provider.litellm.models['dall-e-3']).toBeUndefined()
+    })
+
     it('should merge discovered models with existing config', async () => {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -294,6 +294,45 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.litellm.models['dall-e-3']).toBeUndefined()
     })
 
+    it('should skip embedding models even when model info is missing', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'Qwen/Qwen3-VL-Embedding-8B', object: 'model', created: 1234567890, owned_by: 'openai' },
+              { id: 'Qwen/Qwen3-VL-32B-Instruct', object: 'model', created: 1234567890, owned_by: 'openai' }
+            ]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: [] })
+        })
+
+      const config: any = {
+        provider: {
+          litellm: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LiteLLM',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.litellm.models['Qwen/Qwen3-VL-Embedding-8B']).toBeUndefined()
+      expect(config.provider.litellm.models['Qwen/Qwen3-VL-32B-Instruct']).toEqual(expect.objectContaining({
+        id: 'Qwen/Qwen3-VL-32B-Instruct',
+        modalities: {
+          input: ['text', 'image'],
+          output: ['text']
+        }
+      }))
+    })
+
     it('should merge discovered models with existing config', async () => {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -145,11 +145,8 @@ describe('ModelDiscovery Plugin', () => {
 
       expect(config.provider?.ollama?.models).toBeDefined()
       expect(Object.keys(config.provider.ollama.models).length).toBe(2)
-      expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockFetch).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:11434/v1/models', expect.objectContaining({
-        method: 'GET'
-      }))
-      expect(mockFetch).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:11434/v1/model/info', expect.objectContaining({
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/v1/models', expect.objectContaining({
         method: 'GET'
       }))
     })
@@ -183,11 +180,8 @@ describe('ModelDiscovery Plugin', () => {
       await pluginHooks.config(config)
 
       expect(config.provider.ollama.models['custom-model']).toBeDefined()
-      expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockFetch).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:11434/api/models', expect.objectContaining({
-        method: 'GET'
-      }))
-      expect(mockFetch).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:11434/v1/model/info', expect.objectContaining({
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/models', expect.objectContaining({
         method: 'GET'
       }))
     })
@@ -258,7 +252,10 @@ describe('ModelDiscovery Plugin', () => {
             name: 'LiteLLM',
             options: {
               baseURL: 'http://127.0.0.1:4000/v1',
-              modelsDiscovery: {}
+              modelsDiscovery: {
+                modelInfoEndpoint: '/v1/model/info',
+                modelInfoFormat: 'litellm'
+              }
             },
             models: {}
           }
@@ -295,20 +292,15 @@ describe('ModelDiscovery Plugin', () => {
     })
 
     it('should skip embedding models even when model info is missing', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: [
-              { id: 'Qwen/Qwen3-VL-Embedding-8B', object: 'model', created: 1234567890, owned_by: 'openai' },
-              { id: 'Qwen/Qwen3-VL-32B-Instruct', object: 'model', created: 1234567890, owned_by: 'openai' }
-            ]
-          })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'Qwen/Qwen3-VL-Embedding-8B', object: 'model', created: 1234567890, owned_by: 'openai' },
+            { id: 'Qwen/Qwen3-VL-32B-Instruct', object: 'model', created: 1234567890, owned_by: 'openai' }
+          ]
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ data: [] })
-        })
+      })
 
       const config: any = {
         provider: {
@@ -323,6 +315,7 @@ describe('ModelDiscovery Plugin', () => {
 
       await pluginHooks.config(config)
 
+      expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(config.provider.litellm.models['Qwen/Qwen3-VL-Embedding-8B']).toBeUndefined()
       expect(config.provider.litellm.models['Qwen/Qwen3-VL-32B-Instruct']).toEqual(expect.objectContaining({
         id: 'Qwen/Qwen3-VL-32B-Instruct',


### PR DESCRIPTION
## Summary

Fixes #2.

- Query a LiteLLM-style model info endpoint by default, while gracefully continuing when unavailable.
- Filter non-chat models by default when `model_info.mode` is present.
- Skip embedding models detected from model ids so OpenCode never receives unsupported `embedding` modalities.
- Populate OpenCode context limits from `max_input_tokens`, `max_output_tokens`, and `max_tokens`.
- Populate reasoning and reasoning-effort variants from LiteLLM capability metadata.
- Preserve provider model id casing while using case-insensitive metadata lookup fallback.
- Document provider overrides for custom model info endpoints and disabling non-chat filtering.

## Testing

- `npm run typecheck`
- `npm test -- --run`
- `/bin/opencode debug config --print-logs --log-level ERROR`
- `/bin/opencode models litellm --print-logs --log-level ERROR`
- `/bin/opencode run "Reply with OK only." --model litellm/deepseek-v3.2 --print-logs --log-level ERROR`

## Notes

`npm run lint` currently fails before linting because this repo uses ESLint 9 but only has `.eslintrc.json`, so ESLint cannot find `eslint.config.js`.
