### PR TITLE
feat: add extra fields from model endpoints to OpenCode config

### DIFF
--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -123,10 +123,11 @@ export async function enhanceConfig(
             continue
           }
 
-          const owner = extractModelOwner(model.id)
+          const owner = model.owned_by || extractModelOwner(model.id)
+          const modelName = model.name || (smartModelNameEnabled ? formatModelName(model) : model.id)
           const modelConfig: any = {
             id: model.id,
-            name: smartModelNameEnabled ? formatModelName(model) : model.id,
+            name: modelName,
           }
 
           if (owner) {
@@ -136,9 +137,47 @@ export async function enhanceConfig(
           if (modelType === 'chat') {
             chatModelsCount++
             modelConfig.modalities = {
-              input: ["text", "image"],
+              input: model.capabilities?.vision === true ? ["text", "image"] : ["text"],
               output: ["text"]
             }
+            modelConfig.attachment = model.capabilities?.vision === true
+            modelConfig.temperature = true
+          }
+
+          if (model.capabilities?.reasoning === true) {
+            modelConfig.reasoning = true
+          }
+
+          if (model.capabilities?.tool_call === true) {
+            modelConfig.tool_call = true
+          }
+
+          if (typeof model.context_length === 'number' && model.context_length > 0) {
+            modelConfig.limit = {
+              context: model.context_length,
+              input: model.context_length,
+              output: typeof model.max_output_tokens === 'number' && model.max_output_tokens > 0
+                ? model.max_output_tokens
+                : model.context_length,
+            }
+          }
+
+          if (model.pricing && (model.pricing.input || model.pricing.output)) {
+            modelConfig.cost = {
+              input: model.pricing.input ?? 0,
+              output: model.pricing.output ?? 0,
+            }
+            if (model.pricing.cache_read != null) {
+              modelConfig.cost.cache_read = model.pricing.cache_read
+            }
+            if (model.pricing.cache_write != null) {
+              modelConfig.cost.cache_write = model.pricing.cache_write
+            }
+          }
+
+          if (model.created && model.created > 1609459200) {
+            const date = new Date(model.created * 1000)
+            modelConfig.release_date = date.toISOString().split('T')[0]
           }
 
           modelInfoEnricher?.applyModelInfo(modelConfig, model.id)

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -1,5 +1,5 @@
 import { ToastNotifier } from '../ui/toast-notifier'
-import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
+import { isEmbeddingModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
 import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
@@ -97,7 +97,6 @@ export async function enhanceConfig(
 
       const existingModels = p.models || {}
       const discoveredModels: Record<string, any> = {}
-      let chatModelsCount = 0
 
       const hasProviderModelRegexFilter = !!providerDiscoveryConfig.models?.includeRegex?.length || !!providerDiscoveryConfig.models?.excludeRegex?.length
       const providerModelRegexFilter = getProviderModelRegexFilter(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
@@ -118,8 +117,7 @@ export async function enhanceConfig(
             continue
           }
 
-          const modelType = categorizeModel(model.id)
-          if (modelType === 'embedding') {
+          if (isEmbeddingModel(model.id)) {
             continue
           }
 
@@ -134,15 +132,12 @@ export async function enhanceConfig(
             modelConfig.organizationOwner = owner
           }
 
-          if (modelType === 'chat') {
-            chatModelsCount++
-            modelConfig.modalities = {
-              input: model.capabilities?.vision === true ? ["text", "image"] : ["text"],
-              output: ["text"]
-            }
-            modelConfig.attachment = model.capabilities?.vision === true
-            modelConfig.temperature = true
+          modelConfig.modalities = {
+            input: model.capabilities?.vision === true ? ["text", "image", "video"] : ["text"],
+            output: ["text"]
           }
+          modelConfig.attachment = model.capabilities?.vision === true
+          modelConfig.temperature = true
 
           if (model.capabilities?.reasoning === true) {
             modelConfig.reasoning = true

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,29 @@
+export interface ModelCapabilities {
+  reasoning?: boolean
+  vision?: boolean
+  tool_call?: boolean
+}
+
+export interface ModelPricing {
+  input?: number
+  output?: number
+  cache_read?: number
+  cache_write?: number
+  unit?: string
+  currency?: string
+}
+
 export interface OpenAIModel {
   id: string
   object: string
   created: number
   owned_by: string
+  name?: string
+  type?: string
+  capabilities?: ModelCapabilities
+  context_length?: number
+  max_output_tokens?: number
+  pricing?: ModelPricing
 }
 
 export interface OpenAIModelsResponse {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,16 +1,6 @@
 export { formatModelName, extractModelOwner } from './format-model-name'
 
-// Categorize models by type
-export function categorizeModel(modelId: string): 'chat' | 'embedding' | 'unknown' {
+export function isEmbeddingModel(modelId: string): boolean {
   const lowerId = modelId.toLowerCase()
-  if (lowerId.includes('embedding') || lowerId.includes('embed')) {
-    return 'embedding'
-  }
-  if (lowerId.includes('gpt') || lowerId.includes('llama') || 
-      lowerId.includes('claude') || lowerId.includes('qwen') ||
-      lowerId.includes('mistral') || lowerId.includes('gemma') ||
-      lowerId.includes('phi') || lowerId.includes('falcon')) {
-    return 'chat'
-  }
-  return 'unknown'
+  return lowerId.includes('embedding') || lowerId.includes('embed')
 }


### PR DESCRIPTION
Map additional fields returned by various models endpoints (AxonHub, OpenAI-compatible, etc.):
- name, owned_by
- capabilities (reasoning, vision, tool_call)
- context_length, max_output_tokens
- pricing (input, output, cache_read, cache_write)
- created date (to release_date)

Particularly useful for reasoning models. Unless `reasoning` flag is set, models like DeepSeek V4 will not have toggleable reasoning levels; even though they'll reason by default.