### PR TITLE
feat: add disk-based model cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,49 @@ Control which providers are discovered:
 }
 ```
 
+#### Cache Configuration
+
+Control how discovered models are cached to avoid repeated API calls on every startup. Models are cached to disk at `~/.cache/opencode/models-discovery-cache.json`.
+
+When the cache is fresh, models are served from disk instantly with zero network requests. When expired, stale data is returned immediately while a background refresh fetches the latest models—startup is never blocked by discovery.
+
+Cache keys include provider base URL, endpoint, API key fingerprint, and relevant config (filters, enrichment settings, etc.). Changing any of these automatically invalidates the stale entry and triggers fresh discovery.
+
+Run `opencode models --refresh` to manually clear the cache.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `cache.enabled` | `boolean` | `true` | Enable or disable disk caching |
+| `cache.ttl` | `number` | `3600000` | Cache TTL in milliseconds (default: 1 hour) |
+| `cache.path` | `string` | (auto) | Custom cache file path |
+
+```json
+{
+  "plugin": [
+    ["opencode-models-discovery", {
+      "cache": {
+        "enabled": true,
+        "ttl": 3600000
+      }
+    }]
+  ]
+}
+```
+
+To disable caching:
+
+```json
+{
+  "plugin": [
+    ["opencode-models-discovery", {
+      "cache": {
+        "enabled": false
+      }
+    }]
+  ]
+}
+```
+
 #### Model Filtering
 
 Control which discovered models are auto-injected with regular expressions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.0.166"
@@ -70,6 +70,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -262,6 +296,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@opencode-ai/plugin": {
       "version": "1.4.1",
       "license": "MIT",
@@ -297,6 +350,23 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.0-rc.15",
       "cpu": [
@@ -312,6 +382,247 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
       "dev": true,
@@ -321,6 +632,17 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -350,7 +672,6 @@
       "version": "25.5.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -359,7 +680,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.3",
@@ -488,7 +808,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -688,7 +1007,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1126,6 +1444,27 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
       "cpu": [
@@ -1136,6 +1475,207 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -1327,7 +1867,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1527,6 +2066,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -1567,7 +2114,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1644,7 +2190,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./cache": "./src/cache/model-cache.ts"
   },
   "files": [
     "src"

--- a/src/cache/model-cache.ts
+++ b/src/cache/model-cache.ts
@@ -1,0 +1,226 @@
+const CACHE_VERSION = 1
+const DEFAULT_TTL_MS = 3_600_000
+const CACHE_FILE_NAME = 'models-discovery-cache.json'
+
+type FsPromises = typeof import('node:fs/promises')
+
+const memoryFiles = new Map<string, string>()
+let fsPromises: FsPromises | null | undefined
+
+async function getFs(): Promise<FsPromises | null> {
+  if (fsPromises !== undefined) return fsPromises
+  try {
+    fsPromises = await import('node:fs/promises')
+    return fsPromises
+  } catch {
+    fsPromises = null
+    return null
+  }
+}
+
+function joinPath(...parts: string[]): string {
+  const [first = '', ...rest] = parts
+  const absolutePrefix = first.startsWith('/') ? '/' : ''
+  const start = first.replace(/[\\/]+$/g, '')
+  const tail = rest.map((part) => part.replace(/^[\\/]+|[\\/]+$/g, '')).filter(Boolean)
+  const joined = [start, ...tail].filter(Boolean).join('/')
+  if (absolutePrefix && !joined.startsWith('/')) return `${absolutePrefix}${joined}`
+  return joined || absolutePrefix || '.'
+}
+
+function dirname(filePath: string): string {
+  const normalized = filePath.replace(/[\\/]+$/g, '')
+  const slash = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  if (slash === -1) return '.'
+  if (slash === 0) return normalized[0] ?? '/'
+  return normalized.slice(0, slash)
+}
+
+function cacheTmpPath(filePath: string): string {
+  return joinPath(dirname(filePath), `.${CACHE_FILE_NAME}.tmp.${process.pid}.${Date.now()}`)
+}
+
+export interface CachedProviderModels {
+  key: string
+  models: Record<string, any>
+  discoveredAt: string
+}
+
+export interface ModelCacheData {
+  version: typeof CACHE_VERSION
+  timestamp: string
+  providers: Record<string, CachedProviderModels>
+}
+
+export interface ModelCacheOptions {
+  ttl?: number
+  path?: string
+  log?: (msg: string, extra?: Record<string, unknown>) => void
+}
+
+function defaultCacheDir(): string {
+  if (process.env.VITEST) return joinPath(process.env.TMPDIR ?? '/tmp', 'opencode-models-discovery-cache')
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg) return joinPath(xdg, 'opencode')
+  const home = process.env.HOME ?? process.env.USERPROFILE
+  if (home) return joinPath(home, '.cache', 'opencode')
+  return joinPath(process.cwd(), '.opencode-cache')
+}
+
+function defaultCachePath(): string {
+  return joinPath(defaultCacheDir(), CACHE_FILE_NAME)
+}
+
+function stale(data: ModelCacheData, ttlMs: number): boolean {
+  return Date.now() - new Date(data.timestamp).getTime() > ttlMs
+}
+
+async function readTextFile(filePath: string): Promise<string | null> {
+  const fs = await getFs()
+  if (!fs) {
+    return memoryFiles.get(filePath) ?? null
+  }
+
+  try {
+    return await fs.readFile(filePath, 'utf-8')
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null
+    throw err
+  }
+}
+
+async function writeTextFile(filePath: string, contents: string): Promise<void> {
+  const fs = await getFs()
+  if (!fs) {
+    memoryFiles.set(filePath, contents)
+    return
+  }
+
+  const dir = dirname(filePath)
+  await fs.mkdir(dir, { recursive: true })
+  const tmpPath = cacheTmpPath(filePath)
+  await fs.writeFile(tmpPath, contents, 'utf-8')
+
+  try {
+    await fs.rename(tmpPath, filePath)
+  } catch {
+    await fs.writeFile(filePath, contents, 'utf-8')
+    await fs.unlink(tmpPath).catch(() => {})
+  }
+}
+
+async function deleteFile(filePath: string): Promise<void> {
+  const fs = await getFs()
+  if (!fs) {
+    memoryFiles.delete(filePath)
+    return
+  }
+
+  try {
+    await fs.unlink(filePath)
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err
+  }
+}
+
+export async function readCache(opts?: ModelCacheOptions): Promise<ModelCacheData | null> {
+  const filePath = opts?.path ?? defaultCachePath()
+  try {
+    const raw = await readTextFile(filePath)
+    if (!raw) return null
+    const parsed: ModelCacheData = JSON.parse(raw)
+    if (parsed.version !== CACHE_VERSION) return null
+    return parsed
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      opts?.log?.('Failed to read cache', { path: filePath, error: err?.message ?? String(err) })
+    }
+    return null
+  }
+}
+
+export async function writeCache(data: ModelCacheData, opts?: ModelCacheOptions): Promise<void> {
+  const filePath = opts?.path ?? defaultCachePath()
+  await writeTextFile(filePath, JSON.stringify(data))
+  opts?.log?.('Cache written', { path: filePath })
+}
+
+export function isCacheFresh(data: ModelCacheData, opts?: ModelCacheOptions): boolean {
+  return !stale(data, opts?.ttl ?? DEFAULT_TTL_MS)
+}
+
+export async function clearCache(opts?: ModelCacheOptions): Promise<void> {
+  const filePath = opts?.path ?? defaultCachePath()
+  try {
+    await deleteFile(filePath)
+  } catch {
+  }
+}
+
+function fingerprint(value?: string): string {
+  if (!value) return 'no-key'
+
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `key-${(hash >>> 0).toString(16)}`
+}
+
+export function providerCacheKey(baseURL: string, endpoint: string, apiKey?: string): string {
+  return `${baseURL}|${endpoint}|${fingerprint(apiKey)}`
+}
+
+export interface ModelCache {
+  load(): Promise<ModelCacheData | null>
+  readonly isFresh: boolean
+  getProvider(providerName: string): Record<string, any> | null
+  setProviders(providers: Record<string, CachedProviderModels>): Promise<void>
+  clear(): Promise<void>
+  readonly filePath: string
+}
+
+export function createModelCache(opts?: ModelCacheOptions): ModelCache {
+  const resolvedOpts: ModelCacheOptions = { ttl: DEFAULT_TTL_MS, ...opts }
+  let data: ModelCacheData | null = null
+
+  return {
+    async load(): Promise<ModelCacheData | null> {
+      if (data) return data
+      data = await readCache(resolvedOpts)
+      return data
+    },
+
+    get isFresh(): boolean {
+      if (!data) return false
+      return isCacheFresh(data, resolvedOpts)
+    },
+
+    getProvider(providerName: string): Record<string, any> | null {
+      return data?.providers[providerName]?.models ?? null
+    },
+
+    async setProviders(providers: Record<string, CachedProviderModels>): Promise<void> {
+      const existing = data ?? (await readCache(resolvedOpts))
+      data = {
+        version: CACHE_VERSION,
+        timestamp: new Date().toISOString(),
+        providers: {
+          ...(existing?.providers ?? {}),
+          ...providers,
+        },
+      }
+      await writeCache(data, resolvedOpts)
+    },
+
+    async clear(): Promise<void> {
+      data = null
+      await clearCache(resolvedOpts)
+    },
+
+    get filePath(): string {
+      return resolvedOpts.path ?? defaultCachePath()
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,7 @@
-export { ModelDiscoveryPlugin } from './plugin'
+import { ModelDiscoveryPlugin } from './plugin'
+
+export { ModelDiscoveryPlugin, ModelDiscoveryPlugin as server }
+export default ModelDiscoveryPlugin
+export { createModelCache } from './cache/model-cache'
+export type { ModelCache, ModelCacheData, CachedProviderModels, ModelCacheOptions } from './cache/model-cache'
+export type { CacheConfig } from './types/plugin-config'

--- a/src/plugin/config-hook.ts
+++ b/src/plugin/config-hook.ts
@@ -1,6 +1,6 @@
 import { ToastNotifier } from '../ui/toast-notifier'
 import { validateConfig } from '../utils/validation'
-import { enhanceConfig } from './enhance-config'
+import { enhanceConfig, type EnhanceConfigContext } from './enhance-config'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
 import type { PluginConfig } from '../types/plugin-config'
@@ -14,14 +14,14 @@ export function createConfigHook(
   return async (config: any) => {
     if (config && (Object.isFrozen?.(config) || Object.isSealed?.(config))) {
       logger.warn('Config object is frozen or sealed; cannot modify directly')
-      return
+      return config
     }
 
     const validation = validateConfig(config)
     if (!validation.isValid) {
       logger.error('Invalid config provided', { errors: validation.errors })
       toastNotifier.error("Plugin configuration is invalid", "Configuration Error").catch(() => { })
-      return
+      return config
     }
 
     if (validation.warnings.length > 0) {
@@ -29,26 +29,45 @@ export function createConfigHook(
     }
 
 
+    const mutationContext: EnhanceConfigContext = { allowConfigMutation: true }
     const discoveryPromise = enhanceConfig(
       config,
       client,
       toastNotifier,
       pluginConfig,
-      logger.child({ category: 'discovery' })
+      logger.child({ category: 'discovery' }),
+      mutationContext
     )
     const timeoutMs = 5000
+    let timedOut = false
 
     try {
       await Promise.race([
         discoveryPromise,
         new Promise<void>((resolve) => {
-          setTimeout(() => resolve(), timeoutMs)
-        })
+          setTimeout(() => {
+            timedOut = true
+            mutationContext.allowConfigMutation = false
+            resolve()
+          }, timeoutMs)
+        }),
       ])
     } catch (error) {
-      logger.error('Config enhancement failed', {
-        error: error instanceof Error ? error.message : String(error),
+      if (!timedOut) {
+        logger.error('Config enhancement failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    if (timedOut) {
+      discoveryPromise.catch((error) => {
+        logger.warn('Background config enhancement failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
       })
     }
+
+    return config
   }
 }

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -2,11 +2,11 @@ import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
-import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
+import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride, type PluginConfig, type ProviderDiscoveryConfig } from '../types/plugin-config'
+import { createModelCache, isCacheFresh, providerCacheKey, type CachedProviderModels, type ModelCache, type ModelCacheData } from '../cache/model-cache'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
 import type { OpenAIModel } from '../types'
-import type { PluginConfig } from '../types/plugin-config'
 
 interface DiscoveredProvider {
   name: string
@@ -14,50 +14,165 @@ interface DiscoveredProvider {
   models: Record<string, any>
 }
 
-export async function enhanceConfig(
-  config: any,
-  client: PluginInput['client'],
-  toastNotifier: ToastNotifier,
+export interface EnhanceConfigContext {
+  allowConfigMutation: boolean
+}
+
+function resolveCacheConfig(pluginConfig: PluginConfig): { enabled: boolean; ttl: number; path: string | undefined } {
+  const c = pluginConfig.cache
+  return {
+    enabled: c?.enabled ?? true,
+    ttl: c?.ttl ?? 3_600_000,
+    path: c?.path,
+  }
+}
+
+function buildProviderConfigHash(
+  providerDiscoveryConfig: ProviderDiscoveryConfig,
+  pluginConfig: PluginConfig
+): string {
+  const hasProviderModelRegexFilter =
+    !!providerDiscoveryConfig.models?.includeRegex?.length ||
+    !!providerDiscoveryConfig.models?.excludeRegex?.length
+
+  let smartModelNameEnabled = providerDiscoveryConfig.smartModelName
+  if (smartModelNameEnabled === undefined) {
+    smartModelNameEnabled = pluginConfig.smartModelName
+  }
+
+  return JSON.stringify({
+    smartModelName: smartModelNameEnabled ?? false,
+    modelInfoEndpoint: providerDiscoveryConfig.modelInfoEndpoint ?? '',
+    modelInfoFormat: providerDiscoveryConfig.modelInfoFormat ?? '',
+    filterNonChat: providerDiscoveryConfig.filterNonChat !== false,
+    filters: hasProviderModelRegexFilter
+      ? {
+          includeRegex: providerDiscoveryConfig.models?.includeRegex ?? [],
+          excludeRegex: providerDiscoveryConfig.models?.excludeRegex ?? [],
+        }
+      : {
+          includeRegex: pluginConfig.models?.includeRegex ?? [],
+          excludeRegex: pluginConfig.models?.excludeRegex ?? [],
+        },
+  })
+}
+
+function buildProviderKey(
+  p: any,
+  modelsEndpoint: string,
+  pluginConfig: PluginConfig
+): string {
+  const baseURL = normalizeBaseURL(p.options?.baseURL ?? '')
+  const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
+  const configHash = buildProviderConfigHash(providerDiscoveryConfig, pluginConfig)
+  return `${providerCacheKey(baseURL, modelsEndpoint, p.options?.apiKey)}|${configHash}`
+}
+
+function shouldUseProviderDiscovery(
+  providerName: string,
+  p: any,
   pluginConfig: PluginConfig,
   logger: PluginLogger
-): Promise<void> {
-  try {
-    const providers = config.provider || {}
-    const openAICompatibleProviders: DiscoveredProvider[] = []
-    const providerFilter = getProviderFilter(pluginConfig)
-    const modelRegexFilter = getModelRegexFilter(pluginConfig, logger.child({ category: 'filtering' }))
-    const discoveryConfig = getDiscoveryConfig(pluginConfig)
-    const globalDiscoveryEnabled = discoveryConfig.enabled
+): boolean {
+  if (!p || typeof p !== 'object') {
+    return false
+  }
 
-    for (const [providerName, providerConfig] of Object.entries(providers)) {
-      const p = providerConfig as any
-      const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
-      const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
-      const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint
-      const modelInfoFormat = providerDiscoveryConfig.modelInfoFormat
-      const filterNonChat = providerDiscoveryConfig.filterNonChat !== false
-      const forceDiscoveryEnabled = providerDiscoveryConfig.enabled === true
+  const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
+  const forceDiscoveryEnabled = providerDiscoveryConfig.enabled === true
 
-      if (!forceDiscoveryEnabled && !canDiscoverModels(p)) {
-        continue
-      }
+  if (!p.options?.baseURL) {
+    return false
+  }
 
-      if (!shouldDiscoverProviderWithOverride(providerName, providerFilter, globalDiscoveryEnabled, providerDiscoveryConfig)) {
-        logger.debug(`Provider ${providerName} model discovery disabled by configuration`)
-        continue
-      }
+  if (!forceDiscoveryEnabled && !canDiscoverModels(p)) {
+    return false
+  }
 
-      let baseURL: string
-      let displayName = providerName
+  const providerFilter = getProviderFilter(pluginConfig)
+  const discoveryConfig = getDiscoveryConfig(pluginConfig)
+  if (!shouldDiscoverProviderWithOverride(providerName, providerFilter, discoveryConfig.enabled, providerDiscoveryConfig)) {
+    logger.debug(`Provider ${providerName} model discovery disabled by configuration`)
+    return false
+  }
 
-      if (p.options?.baseURL) {
-        baseURL = normalizeBaseURL(p.options.baseURL)
-      } else {
-        continue
-      }
+  return true
+}
 
-      const apiKey = p.options?.apiKey
+function mergeCachedModels(
+  providers: Record<string, unknown>,
+  cached: ModelCacheData,
+  pluginConfig: PluginConfig,
+  logger: PluginLogger
+): number {
+  let mergedCount = 0
 
+  for (const [providerName, providerConfig] of Object.entries(providers)) {
+    const p = providerConfig as any
+    if (!shouldUseProviderDiscovery(providerName, p, pluginConfig, logger)) {
+      continue
+    }
+
+    const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
+    const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
+    const cachedEntry = cached.providers[providerName]
+
+    if (!cachedEntry?.models || Object.keys(cachedEntry.models).length === 0) {
+      continue
+    }
+
+    const expectedKey = buildProviderKey(p, modelsEndpoint, pluginConfig)
+    if (cachedEntry.key !== expectedKey) {
+      logger.debug('Cache key mismatch, skipping provider cache', {
+        provider: providerName,
+        expectedKey,
+        cachedKey: cachedEntry.key,
+      })
+      continue
+    }
+
+    p.models = { ...cachedEntry.models, ...(p.models || {}) }
+    mergedCount += Object.keys(cachedEntry.models).length
+  }
+
+  return mergedCount
+}
+
+async function discoverProviders(
+  config: any,
+  pluginConfig: PluginConfig,
+  logger: PluginLogger,
+  context: EnhanceConfigContext
+): Promise<DiscoveredProvider[]> {
+  const providers = config.provider || {}
+  const openAICompatibleProviders: DiscoveredProvider[] = []
+  const modelRegexFilter = getModelRegexFilter(pluginConfig, logger.child({ category: 'filtering' }))
+  const discoveryTasks: Promise<void>[] = []
+
+  for (const [providerName, providerConfig] of Object.entries(providers)) {
+    const p = providerConfig as any
+    if (!shouldUseProviderDiscovery(providerName, p, pluginConfig, logger)) {
+      continue
+    }
+
+    const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
+    const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
+    const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint
+    const modelInfoFormat = providerDiscoveryConfig.modelInfoFormat
+    const filterNonChat = providerDiscoveryConfig.filterNonChat !== false
+
+    let baseURL: string
+    const displayName = providerName
+
+    if (p.options?.baseURL) {
+      baseURL = normalizeBaseURL(p.options.baseURL)
+    } else {
+      continue
+    }
+
+    const apiKey = p.options?.apiKey
+
+    const task = (async () => {
       let models: OpenAIModel[]
       const discovery = await discoverModelsFromProvider(baseURL, apiKey, modelsEndpoint)
       if (!discovery.ok) {
@@ -66,13 +181,13 @@ export async function enhanceConfig(
           baseURL,
           endpoint: modelsEndpoint,
         })
-        continue
+        return
       }
 
       models = discovery.models
 
       if (models.length === 0) {
-        continue
+        return
       }
 
       let modelInfoEnricher: ModelInfoEnricher | undefined
@@ -96,10 +211,13 @@ export async function enhanceConfig(
       }
 
       const existingModels = p.models || {}
-      const discoveredModels: Record<string, any> = {}
+      const modelsToAdd: Record<string, any> = {}
+      const cacheModels: Record<string, any> = {}
       let chatModelsCount = 0
 
-      const hasProviderModelRegexFilter = !!providerDiscoveryConfig.models?.includeRegex?.length || !!providerDiscoveryConfig.models?.excludeRegex?.length
+      const hasProviderModelRegexFilter =
+        !!providerDiscoveryConfig.models?.includeRegex?.length ||
+        !!providerDiscoveryConfig.models?.excludeRegex?.length
       const providerModelRegexFilter = getProviderModelRegexFilter(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
       let smartModelNameEnabled = providerDiscoveryConfig.smartModelName
       if (smartModelNameEnabled === undefined) {
@@ -108,81 +226,186 @@ export async function enhanceConfig(
 
       for (const model of models) {
         const modelKey = model.id
+        const activeModelRegexFilter = hasProviderModelRegexFilter ? providerModelRegexFilter : modelRegexFilter
+        if (!shouldDiscoverModel(model.id, activeModelRegexFilter)) {
+          continue
+        }
+
+        if (modelInfoEnricher?.shouldSkipModel(model.id)) {
+          continue
+        }
+
+        const modelType = categorizeModel(model.id)
+        if (modelType === 'embedding') {
+          continue
+        }
+
+        const owner = extractModelOwner(model.id)
+        const modelConfig: any = {
+          id: model.id,
+          name: smartModelNameEnabled ? formatModelName(model) : model.id,
+        }
+
+        if (owner) {
+          modelConfig.organizationOwner = owner
+        }
+
+        if (modelType === 'chat') {
+          chatModelsCount++
+          modelConfig.modalities = {
+            input: ['text', 'image'],
+            output: ['text'],
+          }
+        }
+
+        modelInfoEnricher?.applyModelInfo(modelConfig, model.id)
+
+        cacheModels[modelKey] = modelConfig
         if (!existingModels[modelKey]) {
-          const activeModelRegexFilter = hasProviderModelRegexFilter ? providerModelRegexFilter : modelRegexFilter
-          if (!shouldDiscoverModel(model.id, activeModelRegexFilter)) {
-            continue
-          }
-
-          if (modelInfoEnricher?.shouldSkipModel(model.id)) {
-            continue
-          }
-
-          const modelType = categorizeModel(model.id)
-          if (modelType === 'embedding') {
-            continue
-          }
-
-          const owner = extractModelOwner(model.id)
-          const modelConfig: any = {
-            id: model.id,
-            name: smartModelNameEnabled ? formatModelName(model) : model.id,
-          }
-
-          if (owner) {
-            modelConfig.organizationOwner = owner
-          }
-
-          if (modelType === 'chat') {
-            chatModelsCount++
-            modelConfig.modalities = {
-              input: ["text", "image"],
-              output: ["text"]
-            }
-          }
-
-          modelInfoEnricher?.applyModelInfo(modelConfig, model.id)
-
-          discoveredModels[modelKey] = modelConfig
+          modelsToAdd[modelKey] = modelConfig
         }
       }
 
-      if (Object.keys(discoveredModels).length > 0) {
-        p.models = {
-          ...existingModels,
-          ...discoveredModels,
+      if (Object.keys(cacheModels).length > 0) {
+        if (context.allowConfigMutation && Object.keys(modelsToAdd).length > 0) {
+          p.models = {
+            ...existingModels,
+            ...modelsToAdd,
+          }
         }
 
         openAICompatibleProviders.push({
           name: displayName,
           baseURL,
-          models: discoveredModels
+          models: cacheModels,
         })
       }
-    }
+    })()
 
-    if (openAICompatibleProviders.length > 0) {
-      const totalModels = openAICompatibleProviders.reduce((sum, p) => sum + Object.keys(p.models).length, 0)
-      logger.info('Provider model discovery completed', {
-        providerCount: openAICompatibleProviders.length,
-        modelCount: totalModels,
+    discoveryTasks.push(task)
+  }
+
+  const results = await Promise.allSettled(discoveryTasks)
+  for (const [index, result] of results.entries()) {
+    if (result.status === 'rejected') {
+      logger.warn('Provider model discovery task failed', {
+        taskIndex: index,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
       })
     }
+  }
 
-    if (Object.keys(providers).length === 0) {
-      const detected = await autoDetectOpenAICompatibleProvider()
-      if (detected) {
-        logger.info('Detected OpenAI-compatible provider but found no configured providers', {
-          provider: detected.name,
-          baseURL: detected.baseURL,
+  if (openAICompatibleProviders.length > 0) {
+    const totalModels = openAICompatibleProviders.reduce((sum, provider) => sum + Object.keys(provider.models).length, 0)
+    logger.info('Provider model discovery completed', {
+      providerCount: openAICompatibleProviders.length,
+      modelCount: totalModels,
+      configMutation: context.allowConfigMutation,
+    })
+  }
+
+  if (Object.keys(providers).length === 0) {
+    const detected = await autoDetectOpenAICompatibleProvider()
+    if (detected) {
+      logger.info('Detected OpenAI-compatible provider but found no configured providers', {
+        provider: detected.name,
+        baseURL: detected.baseURL,
+      })
+    }
+  }
+
+  return openAICompatibleProviders
+}
+
+async function writeDiscoveredProvidersToCache(
+  cache: ModelCache,
+  config: any,
+  discoveredProviders: DiscoveredProvider[],
+  pluginConfig: PluginConfig
+): Promise<void> {
+  if (discoveredProviders.length === 0) {
+    return
+  }
+
+  const cacheProviders: Record<string, CachedProviderModels> = {}
+  for (const provider of discoveredProviders) {
+    const p = config.provider?.[provider.name] as any
+    const providerDiscoveryConfig = p?.options?.modelsDiscovery ?? {}
+    const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
+    cacheProviders[provider.name] = {
+      key: buildProviderKey(p, modelsEndpoint, pluginConfig),
+      models: provider.models,
+      discoveredAt: new Date().toISOString(),
+    }
+  }
+
+  await cache.setProviders(cacheProviders)
+}
+
+export async function enhanceConfig(
+  config: any,
+  client: PluginInput['client'],
+  toastNotifier: ToastNotifier,
+  pluginConfig: PluginConfig,
+  logger: PluginLogger,
+  context: EnhanceConfigContext = { allowConfigMutation: true }
+): Promise<void> {
+  const cacheCfg = resolveCacheConfig(pluginConfig)
+  const cache = createModelCache({
+    ttl: cacheCfg.ttl,
+    path: cacheCfg.path,
+    log: (msg, extra) => logger.debug(msg, extra ?? {}),
+  })
+
+  try {
+    const providers = config.provider || {}
+    if (cacheCfg.enabled) {
+      const cached = await cache.load()
+
+      if (cached && isCacheFresh(cached, { ttl: cacheCfg.ttl })) {
+        const mergedCount = mergeCachedModels(providers, cached, pluginConfig, logger)
+        if (mergedCount > 0) {
+          logger.info('Using cached model discovery', {
+            providerCount: Object.keys(cached.providers).length,
+            modelCount: mergedCount,
+          })
+          return
+        }
+        logger.debug('Fresh cache has no matching provider entries, discovering models')
+      } else if (cached) {
+        const mergedCount = mergeCachedModels(providers, cached, pluginConfig, logger)
+        if (mergedCount > 0) {
+          logger.info('Cache is stale, using cached models and refreshing in background', {
+            age: Date.now() - new Date(cached.timestamp).getTime(),
+            modelCount: mergedCount,
+          })
+
+          const backgroundContext: EnhanceConfigContext = { allowConfigMutation: false }
+          void discoverProviders(config, pluginConfig, logger, backgroundContext)
+            .then((discoveredProviders) => writeDiscoveredProvidersToCache(cache, config, discoveredProviders, pluginConfig))
+            .catch((error) => {
+              logger.warn('Background cache refresh failed', {
+                error: error instanceof Error ? error.message : String(error),
+              })
+            })
+
+          return
+        }
+        logger.info('Cache is stale with no matching provider entries, discovering models', {
+          age: Date.now() - new Date(cached.timestamp).getTime(),
         })
       }
     }
 
+    const discoveredProviders = await discoverProviders(config, pluginConfig, logger, context)
+
+    if (cacheCfg.enabled) {
+      await writeDiscoveredProvidersToCache(cache, config, discoveredProviders, pluginConfig)
+    }
   } catch (error) {
     logger.error('Unexpected error in enhanceConfig', {
       error: error instanceof Error ? error.message : String(error),
     })
-    toastNotifier.warning("Plugin configuration failed", "Configuration Error").catch(() => { })
+    toastNotifier.warning('Plugin configuration failed', 'Configuration Error').catch(() => {})
   }
 }

--- a/src/plugin/event-hook.ts
+++ b/src/plugin/event-hook.ts
@@ -1,16 +1,29 @@
 import { validateHookInput } from '../utils/validation'
 import type { PluginLogger } from './logger'
 
-export function createEventHook(logger: PluginLogger) {
+export function createEventHook(
+  logger: PluginLogger,
+  invalidateCache?: () => Promise<void>,
+) {
   return async ({ event }: { event: any }) => {
     const validation = validateHookInput('event', { event })
     if (!validation.isValid) {
       logger.error('Invalid event input', { errors: validation.errors })
       return
     }
-    
+
     if (event.type === "session.created" || event.type === "session.updated") {
-      // Reserved for future session-aware discovery diagnostics.
+      return
+    }
+
+    if (
+      event.type === "command.executed"
+      && event.properties?.name === "models"
+      && typeof event.properties?.arguments === "string"
+      && event.properties.arguments.includes("--refresh")
+    ) {
+      logger.info("Models refresh detected, clearing discovery cache")
+      await invalidateCache?.()
     }
   }
 }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -5,6 +5,7 @@ import { createEventHook } from './event-hook'
 import { createChatParamsHook } from './chat-params-hook'
 import { createPluginLogger } from './logger'
 import { parsePluginConfig, type PluginConfig } from '../types/plugin-config'
+import { clearCache } from '../cache/model-cache'
 
 export const ModelDiscoveryPlugin: Plugin = async (input: PluginInput, options?: PluginOptions) => {
   const { client } = input
@@ -13,7 +14,7 @@ export const ModelDiscoveryPlugin: Plugin = async (input: PluginInput, options?:
   if (!client || typeof client !== 'object') {
     logger.error('Invalid client provided to plugin')
     return {
-      config: async () => { },
+      config: async (config: any) => config,
       event: async () => { },
       "chat.params": async () => { }
     }
@@ -31,7 +32,7 @@ export const ModelDiscoveryPlugin: Plugin = async (input: PluginInput, options?:
 
   return {
     config: createConfigHook(client, toastNotifier, pluginConfig, logger.child({ category: 'config' })),
-    event: createEventHook(logger.child({ category: 'event' })),
+    event: createEventHook(logger.child({ category: 'event' }), () => clearCache({ path: pluginConfig.cache?.path })),
     "chat.params": createChatParamsHook(toastNotifier, pluginConfig),
   }
 }

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -1,3 +1,9 @@
+export interface CacheConfig {
+  enabled?: boolean
+  ttl?: number
+  path?: string
+}
+
 export interface PluginConfig {
   providers?: {
     include?: string[]
@@ -10,6 +16,7 @@ export interface PluginConfig {
   discovery?: {
     enabled?: boolean
   }
+  cache?: CacheConfig
   smartModelName?: boolean
 }
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { ModelDiscoveryPlugin } from '../src/index.ts'
+import { clearCache, readCache } from '../src/cache/model-cache.ts'
 
 const mockFetch = vi.fn()
 global.fetch = mockFetch
@@ -46,8 +47,9 @@ describe('ModelDiscovery Plugin', () => {
     pluginHooks = await ModelDiscoveryPlugin(mockInput)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks()
+    await clearCache()
   })
 
   describe('Plugin Initialization', () => {
@@ -1048,6 +1050,254 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toBeDefined()
       expect(config.provider.ollama.models['qwen/qwen3-8b']).toBeDefined()
       expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
+    })
+
+    it('should not inject cached models for excluded providers', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'cached-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+      expect(config.provider.ollama.models['cached-model']).toBeDefined()
+
+      mockFetch.mockClear()
+      const hooksWithExclude = await ModelDiscoveryPlugin({
+        client: mockClient,
+        project: {
+          id: 'test-project',
+          name: 'test',
+          path: '/tmp',
+          worktree: '',
+          time: { created: Date.now() }
+        },
+        directory: '/tmp',
+        worktree: '',
+        $: vi.fn()
+      }, {
+        providers: {
+          exclude: ['ollama']
+        }
+      })
+
+      const configWithExclude: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await hooksWithExclude.config(configWithExclude)
+
+      expect(configWithExclude.provider.ollama.models).toEqual({})
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('should not inject cached models when provider-level discovery is disabled', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'cached-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+      expect(config.provider.ollama.models['cached-model']).toBeDefined()
+
+      mockFetch.mockClear()
+      const configWithProviderDisabled: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: {
+              baseURL: 'http://127.0.0.1:11434/v1',
+              modelsDiscovery: {
+                enabled: false
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(configWithProviderDisabled)
+
+      expect(configWithProviderDisabled.provider.ollama.models).toEqual({})
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('should invalidate provider cache when api key changes', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'model-for-key-a', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const configForKeyA: any = {
+        provider: {
+          openrouter: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'OpenRouter',
+            options: {
+              baseURL: 'https://openrouter.ai/api/v1',
+              apiKey: 'key-a'
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(configForKeyA)
+      expect(configForKeyA.provider.openrouter.models['model-for-key-a']).toBeDefined()
+
+      mockFetch.mockClear()
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'model-for-key-b', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const configForKeyB: any = {
+        provider: {
+          openrouter: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'OpenRouter',
+            options: {
+              baseURL: 'https://openrouter.ai/api/v1',
+              apiKey: 'key-b'
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(configForKeyB)
+
+      expect(configForKeyB.provider.openrouter.models['model-for-key-a']).toBeUndefined()
+      expect(configForKeyB.provider.openrouter.models['model-for-key-b']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith('https://openrouter.ai/api/v1/models', expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer key-b'
+        })
+      }))
+    })
+
+    it('should refresh stale cache in background even when model ids are unchanged', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'same-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+      const firstCache = await readCache()
+      const firstDiscoveredAt = firstCache?.providers.ollama.discoveredAt
+      expect(firstDiscoveredAt).toBeDefined()
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      const hooksWithStaleCache = await ModelDiscoveryPlugin({
+        client: mockClient,
+        project: {
+          id: 'test-project',
+          name: 'test',
+          path: '/tmp',
+          worktree: '',
+          time: { created: Date.now() }
+        },
+        directory: '/tmp',
+        worktree: '',
+        $: vi.fn()
+      }, {
+        cache: {
+          ttl: -1
+        }
+      })
+
+      mockFetch.mockClear()
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'same-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const staleConfig: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await hooksWithStaleCache.config(staleConfig)
+
+      expect(staleConfig.provider.ollama.models['same-model']).toBeDefined()
+
+      await vi.waitFor(async () => {
+        const refreshedCache = await readCache()
+        expect(refreshedCache?.providers.ollama.discoveredAt).not.toBe(firstDiscoveredAt)
+      })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
@@ -16,4 +17,3 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"]
 }
-


### PR DESCRIPTION
Persist discovered provider models to disk to avoid repeated API calls on startup.

- New `src/cache/model-cache.ts`: atomic write (tmp+rename), FNV-1a API key
  fingerprinting, XDG-compatible paths, in-memory fallback when fs unavailable
- Refactor `enhanceConfig` into focused functions (`discoverProviders`,
  `mergeCachedModels`, `writeDiscoveredProvidersToCache`) with stale-while-revalidate
  via `EnhanceConfigContext.allowConfigMutation`
- Config hook: 5s timeout with background continuation; timed-out discovery
  still populates cache for next startup
- Event hook: listen for `models --refresh` to clear cache on demand
- `PluginConfig` gains `cache { enabled, ttl, path }` (defaults: enabled=true, ttl=1h)
- Export `createModelCache` + types from `index.ts` with `./cache` subpath export
- 5 new test cases: excluded providers, disabled discovery, API key change
  invalidation, stale background refresh