### PR TITLE
feat: support connect-backed model discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,28 +44,58 @@ Add the plugin to your `opencode.json`:
     "opencode-models-discovery@latest"
   ],
   "provider": {
-    "deepseek": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "DeepSeek",
-      "options": {
-        "baseURL": "https://api.deepseek.com",
-        "apiKey": "YOUR_DEEPSEEK_API_KEY",
-        "modelsDiscovery": {
-          "enabled": true,
-          "endpoint": "/models"
-        }
-      }
-    },
     "lmstudio": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "LM Studio (local)",
       "options": {
-        "baseURL": "http://127.0.0.1:1234/v1"
+        "baseURL": "http://127.0.0.1:1234/v1",
+        "modelsDiscovery": {
+          "enabled": true
+        }
       }
     }
   }
 }
 ```
+
+### Using `/connect` for Custom Providers
+
+For custom OpenAI-compatible providers, you still need to define the provider itself in `opencode.json` so OpenCode and this plugin know the provider id, npm package, and `baseURL`.
+
+However, you do **not** have to hardcode `options.apiKey` when the provider credential is managed through OpenCode `/connect`.
+
+Example:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "opencode-models-discovery@latest"
+  ],
+  "provider": {
+    "test_provider": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Test Provider",
+      "options": {
+        "baseURL": "http://127.0.0.1:4000/v1",
+        "modelsDiscovery": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+Then run `/connect`, choose the same provider id, and save the API key there.
+
+Credential precedence for discovery requests is:
+
+1. `provider.<name>.options.apiKey`
+2. OpenCode resolved provider key, when available during plugin startup
+3. OpenCode `/connect` auth store for same-id `type: "api"` credentials
+
+This means existing explicit `apiKey` configs keep working, while custom providers can also rely on `/connect` without duplicating the key in `opencode.json`.
 
 ### Configuration
 
@@ -331,9 +361,16 @@ Regex filtering only applies to auto-discovered models. Models already explicitl
 1. On OpenCode startup, the plugin's `config` hook is called
 2. The plugin iterates through all configured providers
 3. For each provider, it checks whether it is OpenAI-compatible by npm, by a `/v1` baseURL, by an explicit discovery endpoint override, or by a forced provider-level discovery override
-4. For each accessible provider, it queries the configured models endpoint, defaulting to `/v1/models`
-5. Discovered models are automatically merged into the provider's configuration
-6. The enhanced configuration is used for the current session
+4. For each accessible provider, it resolves discovery auth from explicit config first and then from OpenCode-managed auth when available
+5. It queries the configured models endpoint, defaulting to `/v1/models`
+6. Discovered models are automatically merged into the provider's configuration
+7. The enhanced configuration is used for the current session
+
+Notes:
+
+- OpenCode's provider resolution API can time out inside the `config` hook, so the plugin includes a fallback for `/connect` API-key credentials.
+- That fallback first respects `OPENCODE_AUTH_CONTENT`, then reads the same OpenCode auth store location derived from `xdg-basedir` that OpenCode uses for `Global.Path.data`.
+- The plugin never writes the recovered key back into `opencode.json` and never logs the secret value.
 
 ### Supported Providers
 
@@ -471,6 +508,16 @@ This means providers using `@ai-sdk/anthropic` with OpenAI-compatible backends a
 When available, the plugin writes logs through OpenCode's structured server log API via `client.app.log(...)` using the service name `opencode-models-discovery`.
 
 If structured logging is unavailable in the runtime, the plugin falls back to prefixed `console.*` output. Key log categories are emitted through metadata such as `plugin`, `config`, `discovery`, `event`, and `filtering` to make local debugging easier with `opencode --print-logs`.
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=yuhp%2Fopencode-models-discovery&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=yuhp/opencode-models-discovery&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=yuhp/opencode-models-discovery&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=yuhp/opencode-models-discovery&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## License
 

--- a/docs/issue-5-auth-discovery.md
+++ b/docs/issue-5-auth-discovery.md
@@ -1,0 +1,266 @@
+# Issue #5: Auth-Backed Model Discovery for Custom Providers
+
+## Summary
+
+Issue #5 asks whether `opencode-models-discovery` can use credentials stored by OpenCode's `/connect` flow instead of requiring `provider.<id>.options.apiKey` in `opencode.json`.
+
+The initial concern looked like it might overlap with built-in OpenCode providers, because built-in providers connected through `/connect` usually already expose their model lists through OpenCode itself. The follow-up clarified that the affected case is different: a custom OpenAI-compatible provider uses `/connect` for credentials, but still needs this plugin for dynamic model discovery.
+
+## User Scenario
+
+The reported setup is a local LiteLLM proxy configured as a custom OpenAI-compatible provider:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    ["opencode-models-discovery", {
+      "providers": { "include": ["breeze"] },
+      "smartModelName": true
+    }]
+  ],
+  "provider": {
+    "breeze": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Breeze",
+      "options": {
+        "baseURL": "http://localhost:4000/v1"
+      }
+    }
+  }
+}
+```
+
+OpenCode `/connect` is then used with the `other custom provider` flow. OpenCode stores the API credential under the same provider id:
+
+```json
+{
+  "breeze": {
+    "type": "api",
+    "key": "sk-..."
+  }
+}
+```
+
+OpenCode stores the credential successfully, but it does not automatically discover and expose the LiteLLM model list for this custom provider. This plugin is expected to perform that discovery, but it currently sends the model discovery request without the `/connect` credential.
+
+## Current Behavior
+
+The plugin currently discovers models during the `config` hook. For each provider it reads only the API key from provider options:
+
+```ts
+const apiKey = p.options?.apiKey
+```
+
+That value is passed to the model discovery request and, when present, becomes a Bearer token:
+
+```ts
+headers["Authorization"] = `Bearer ${apiKey}`
+```
+
+If the provider config omits `options.apiKey`, the discovery request is unauthenticated. For auth-protected LiteLLM or gateway deployments, `/v1/models` then fails or returns no usable result.
+
+## Expected Behavior
+
+For custom OpenAI-compatible providers, the plugin should ideally be able to reuse the provider credential already resolved by OpenCode when all of the following are true:
+
+1. The provider is configured in `opencode.json`.
+2. The provider id matches a credential created through `/connect`.
+3. The credential is available through an official OpenCode plugin or SDK API.
+4. No explicit `provider.<id>.options.apiKey` is configured.
+
+An explicit `options.apiKey` should keep priority over any resolved auth credential to preserve existing behavior and user intent.
+
+## Why Built-In Providers Are Different
+
+For built-in providers, OpenCode typically owns both authentication and model listing. The documented flow is:
+
+1. Run `/connect`.
+2. Add the provider credential.
+3. Run `/models` and select from the provider's available models.
+
+For those providers, this plugin should not need to read OpenCode auth or duplicate model discovery. Duplicating discovery could conflict with OpenCode's provider directory, Models.dev metadata, or provider-specific model definitions.
+
+The issue is therefore scoped to custom providers whose credentials are managed by OpenCode but whose models are not automatically populated by OpenCode.
+
+## Why Direct `auth.json` Reads Are Risky
+
+The plugin should avoid directly reading `~/.local/share/opencode/auth.json`.
+
+Reasons:
+
+1. The path is an OpenCode implementation detail and may vary by platform, version, or environment.
+2. The file format is an internal storage format, not a stable plugin API.
+3. Reading auth files directly expands the plugin's security responsibility.
+4. It could bypass future OpenCode auth behavior such as refresh, migration, encryption, provider aliases, or workspace-specific auth resolution.
+
+The right target is not `auth.json` as a file. The right target is OpenCode's resolved provider authentication, if exposed through a supported API.
+
+## Relevant OpenCode Plugin APIs
+
+The installed `@opencode-ai/plugin` types show a provider hook with auth context:
+
+```ts
+export type ProviderHookContext = {
+  auth?: Auth
+}
+
+export type ProviderHook = {
+  id: string
+  models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
+}
+```
+
+This suggests that `provider.models` may be the official auth-aware path for dynamic model listing. However, this project currently uses the `config` hook to mutate provider configuration, so adopting `provider.models` may require an architectural change or an additional code path.
+
+The SDK types also expose resolved providers with fields such as `id`, `source`, `key`, `options`, and `models`. This may allow investigation into whether `client.config.providers()` can return a resolved provider key during the `config` hook, but that needs runtime validation.
+
+## Possible Implementation Paths
+
+### Option 1: Resolve Provider Key During Config Hook
+
+Investigate whether `client.config.providers()` can be called from the `config` hook and whether it returns the `/connect` credential as `provider.key` for custom providers.
+
+Benefits:
+
+1. Minimal disruption to the current architecture.
+2. Existing config mutation behavior can remain mostly unchanged.
+3. Provider-level filtering and model enrichment can continue to work in the same path.
+
+Risks:
+
+1. The resolved provider list may not be available yet during the config hook.
+2. Calling config/provider resolution from inside a config hook may be recursive or unstable.
+3. The returned `key` field may not be intended for plugin use.
+
+### Option 2: Add or Migrate to Provider Models Hook
+
+Use OpenCode's `provider.models` hook, where `ctx.auth` appears to be provided explicitly.
+
+Benefits:
+
+1. Likely the most official auth-aware mechanism.
+2. Avoids direct auth store access.
+3. Better semantic fit for dynamic model listing.
+
+Risks:
+
+1. The hook shape appears to target one provider id at a time, while this plugin currently discovers models for all configured providers.
+2. It may require users to configure the plugin differently or require one hook per provider.
+3. Existing behavior based on config injection may need compatibility handling.
+4. Model metadata enrichment and provider/model filters would need to be mapped into the hook flow.
+
+### Option 3: Document Explicit Credential Workarounds Only
+
+Keep the current plugin behavior and document that discovery credentials must be configured explicitly for custom providers.
+
+Recommended examples:
+
+```jsonc
+{
+  "provider": {
+    "breeze": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Breeze",
+      "options": {
+        "baseURL": "http://localhost:4000/v1",
+        "apiKey": "{env:BREEZE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+```jsonc
+{
+  "provider": {
+    "breeze": {
+      "options": {
+        "baseURL": "http://localhost:4000/v1",
+        "apiKey": "{file:~/.secrets/breeze-key}"
+      }
+    }
+  }
+}
+```
+
+Benefits:
+
+1. No dependency on uncertain OpenCode plugin behavior.
+2. Keeps security and behavior explicit.
+3. Works today.
+
+Risks:
+
+1. Users must duplicate credentials outside `/connect`.
+2. The plugin remains less integrated with OpenCode's auth flow.
+3. The issue's core request remains unresolved.
+
+## Recommended Direction
+
+Treat the issue as a valid feature request for custom providers, but do not implement direct `auth.json` parsing.
+
+Recommended investigation order:
+
+1. Verify whether resolved auth can be accessed safely from the current `config` hook.
+2. If not, verify whether `provider.models` can support this plugin's multi-provider discovery model.
+3. If neither official path works, document explicit credential configuration as the supported approach and explain why `/connect` credentials cannot currently be reused.
+
+## Implementation Direction
+
+The plugin now follows Option 1 for the current config-hook architecture.
+
+During model discovery it attempts to read OpenCode's resolved providers through `client.config.providers()`. When OpenCode returns a provider entry with a `key`, the plugin can use that key as the discovery credential for the matching configured provider id.
+
+Credential precedence is:
+
+1. `provider.<id>.options.apiKey`
+2. Resolved OpenCode provider `key`, which may come from `/connect` auth or environment resolution
+3. No credential
+
+This keeps explicit project configuration as the highest-priority source while allowing custom providers such as `test_provider` or `breeze` to omit `options.apiKey` and reuse credentials saved through `/connect`.
+
+If `client.config.providers()` is unavailable, fails, or returns an unexpected shape, discovery falls back to the previous behavior and continues without resolved auth. The plugin still does not read `auth.json` directly.
+
+Runtime validation showed that `client.config.providers()` can time out when called from the OpenCode `config` hook. To keep existing providers working, the plugin only attempts this lookup when a provider does not already have `options.apiKey`, and the lookup has a short timeout.
+
+Because the resolved provider API is not currently reliable in the config hook, the implementation includes a constrained fallback for `/connect` credentials:
+
+1. Respect `OPENCODE_AUTH_CONTENT` when present, matching OpenCode's own auth override behavior.
+2. Read the OpenCode auth store from `path.join(xdgData, "opencode", "auth.json")`, matching OpenCode's `Global.Path.data` construction from `xdg-basedir`, only when no explicit `options.apiKey` exists and resolved provider lookup did not provide a key.
+3. Use only same-id `type: "api"` credentials for discovery.
+4. Never write the credential back into `opencode.json` or log the credential value.
+
+This fallback is less ideal than a first-class plugin auth API, but it is currently necessary for auth-backed discovery from the config hook.
+
+## Temporary Workarounds
+
+Users can provide the LiteLLM or gateway credential explicitly without hardcoding it in the config.
+
+Environment variable:
+
+```jsonc
+"options": {
+  "baseURL": "http://localhost:4000/v1",
+  "apiKey": "{env:BREEZE_API_KEY}"
+}
+```
+
+File substitution:
+
+```jsonc
+"options": {
+  "baseURL": "http://localhost:4000/v1",
+  "apiKey": "{file:~/.secrets/breeze-key}"
+}
+```
+
+## Open Questions
+
+1. Does `client.config.providers()` return `provider.key` for a custom provider connected through `/connect` during the `config` hook?
+2. If it does, is that field part of a stable API contract for plugins?
+3. Does calling `client.config.providers()` from the `config` hook cause recursion or timing issues?
+4. Can a plugin register dynamic `provider.models` behavior for arbitrary configured providers, or only for a fixed provider id?
+5. Can the current config-hook injection path coexist with a provider-hook path without duplicate model entries?
+6. How should OAuth or non-API-key auth types behave for OpenAI-compatible discovery requests?
+7. Should auth-backed discovery be opt-in per provider, or should it be the default fallback when `options.apiKey` is absent?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.0.166"
+        "@opencode-ai/plugin": "^1.0.166",
+        "xdg-basedir": "^5.1.0"
       },
       "devDependencies": {
         "@types/node": "^25.0.3",
@@ -70,6 +71,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -262,6 +274,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@opencode-ai/plugin": {
       "version": "1.4.1",
       "license": "MIT",
@@ -297,6 +328,23 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.0-rc.15",
       "cpu": [
@@ -312,6 +360,229 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
       "dev": true,
@@ -321,6 +592,17 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1126,6 +1408,27 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
       "cpu": [
@@ -1136,6 +1439,195 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -1527,6 +2019,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -1763,6 +2263,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "url": "git+https://github.com/yuhp/opencode-models-discovery.git"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.0.166"
+    "@opencode-ai/plugin": "^1.0.166",
+    "xdg-basedir": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { xdgData } from 'xdg-basedir'
 import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
@@ -14,6 +17,138 @@ interface DiscoveredProvider {
   models: Record<string, any>
 }
 
+interface ResolvedProvider {
+  id?: string
+  key?: string
+}
+
+interface ResolvedProvidersLoader {
+  promise?: Promise<Map<string, ResolvedProvider>>
+}
+
+interface OpenCodeAuth {
+  type?: string
+  key?: string
+}
+
+const RESOLVED_PROVIDERS_TIMEOUT_MS = 250
+
+async function getResolvedProvidersByID(
+  client: PluginInput['client'],
+  logger: PluginLogger,
+  timeoutMs: number = RESOLVED_PROVIDERS_TIMEOUT_MS
+): Promise<Map<string, ResolvedProvider>> {
+  try {
+    const loadProviders = client.config?.providers
+    if (typeof loadProviders !== 'function') {
+      return new Map()
+    }
+
+    const result = await Promise.race([
+      loadProviders.call(client.config),
+      new Promise<undefined>((resolve) => {
+        setTimeout(() => resolve(undefined), timeoutMs)
+      })
+    ])
+
+    if (!result) {
+      logger.debug('Timed out loading resolved providers')
+      return new Map()
+    }
+
+    const providers = result?.data?.providers
+    if (!Array.isArray(providers)) {
+      return new Map()
+    }
+
+    return new Map(
+      providers
+        .filter((provider: ResolvedProvider) => typeof provider?.id === 'string')
+        .map((provider: ResolvedProvider) => [provider.id!, provider])
+    )
+  } catch (error) {
+    logger.debug('Could not load resolved providers', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return new Map()
+  }
+}
+
+function getOpenCodeAuthFile(): string | undefined {
+  if (!xdgData) {
+    return undefined
+  }
+
+  return path.join(xdgData, 'opencode', 'auth.json')
+}
+
+async function getOpenCodeAuth(providerName: string, logger: PluginLogger): Promise<OpenCodeAuth | undefined> {
+  const normalizedProviderName = providerName.replace(/\/+$/, '')
+
+  try {
+    if (process.env.OPENCODE_AUTH_CONTENT) {
+      const auths = JSON.parse(process.env.OPENCODE_AUTH_CONTENT) as Record<string, OpenCodeAuth>
+      return auths[providerName] ?? auths[normalizedProviderName] ?? auths[`${normalizedProviderName}/`]
+    }
+  } catch (error) {
+    logger.debug('Could not parse OPENCODE_AUTH_CONTENT', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  const file = getOpenCodeAuthFile()
+  if (file) {
+    try {
+      const auths = JSON.parse(await fs.readFile(file, 'utf8')) as Record<string, OpenCodeAuth>
+      return auths[providerName] ?? auths[normalizedProviderName] ?? auths[`${normalizedProviderName}/`]
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT') {
+        logger.debug('Could not read OpenCode auth store', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  return undefined
+}
+
+function getConfiguredApiKey(providerConfig: any): string | undefined {
+  const explicitApiKey = providerConfig.options?.apiKey
+  if (typeof explicitApiKey === 'string' && explicitApiKey.trim().length > 0) {
+    return explicitApiKey
+  }
+
+  return undefined
+}
+
+async function getProviderApiKey(
+  providerName: string,
+  providerConfig: any,
+  client: PluginInput['client'],
+  loader: ResolvedProvidersLoader,
+  logger: PluginLogger
+): Promise<string | undefined> {
+  const explicitApiKey = getConfiguredApiKey(providerConfig)
+  if (explicitApiKey) {
+    return explicitApiKey
+  }
+
+  loader.promise ??= getResolvedProvidersByID(client, logger)
+  const resolvedProvider = (await loader.promise).get(providerName)
+
+  if (typeof resolvedProvider?.key === 'string' && resolvedProvider.key.trim().length > 0) {
+    return resolvedProvider.key
+  }
+
+  const auth = await getOpenCodeAuth(providerName, logger)
+  if (auth?.type === 'api' && typeof auth.key === 'string' && auth.key.trim().length > 0) {
+    return auth.key
+  }
+
+  return undefined
+}
+
 export async function enhanceConfig(
   config: any,
   client: PluginInput['client'],
@@ -28,6 +163,7 @@ export async function enhanceConfig(
     const modelRegexFilter = getModelRegexFilter(pluginConfig, logger.child({ category: 'filtering' }))
     const discoveryConfig = getDiscoveryConfig(pluginConfig)
     const globalDiscoveryEnabled = discoveryConfig.enabled
+    const resolvedProvidersLoader: ResolvedProvidersLoader = {}
 
     for (const [providerName, providerConfig] of Object.entries(providers)) {
       const p = providerConfig as any
@@ -56,7 +192,7 @@ export async function enhanceConfig(
         continue
       }
 
-      const apiKey = p.options?.apiKey
+      const apiKey = await getProviderApiKey(providerName, p, client, resolvedProvidersLoader, logger)
 
       let models: OpenAIModel[]
       const discovery = await discoverModelsFromProvider(baseURL, apiKey, modelsEndpoint)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -18,10 +18,14 @@ describe('ModelDiscovery Plugin', () => {
 
   beforeEach(async () => {
     mockFetch.mockClear()
+    delete process.env.OPENCODE_AUTH_CONTENT
 
     mockClient = {
       app: {
         log: vi.fn().mockResolvedValue(true)
+      },
+      config: {
+        providers: vi.fn().mockResolvedValue({ data: { providers: [] } })
       },
       tui: {
         showToast: vi.fn().mockResolvedValue(true)
@@ -47,6 +51,7 @@ describe('ModelDiscovery Plugin', () => {
   })
 
   afterEach(() => {
+    delete process.env.OPENCODE_AUTH_CONTENT
     vi.restoreAllMocks()
   })
 
@@ -148,6 +153,196 @@ describe('ModelDiscovery Plugin', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/v1/models', expect.objectContaining({
         method: 'GET'
+      }))
+    })
+
+    it('should use resolved provider key from OpenCode auth when options.apiKey is absent', async () => {
+      mockClient.config.providers.mockResolvedValueOnce({
+        data: {
+          providers: [
+            { id: 'test_provider', key: 'connected-key' }
+          ]
+        }
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'connected-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.test_provider.models['connected-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer connected-key'
+        })
+      }))
+    })
+
+    it('should prefer explicit options.apiKey over resolved provider key', async () => {
+      mockClient.config.providers.mockResolvedValueOnce({
+        data: {
+          providers: [
+            { id: 'test_provider', key: 'connected-key' }
+          ]
+        }
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'explicit-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              apiKey: 'explicit-key'
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.test_provider.models['explicit-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer explicit-key'
+        })
+      }))
+    })
+
+    it('should not block explicit apiKey providers on resolved provider loading', async () => {
+      mockClient.config.providers.mockImplementationOnce(() => new Promise(() => {}))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'explicit-fast-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          hyy: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'HYY',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              apiKey: 'explicit-key'
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockClient.config.providers).not.toHaveBeenCalled()
+      expect(config.provider.hyy.models['explicit-fast-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer explicit-key'
+        })
+      }))
+    })
+
+    it('should continue discovery without auth when resolved providers cannot be loaded', async () => {
+      mockClient.config.providers.mockRejectedValueOnce(new Error('provider resolution failed'))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'fallback-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          no_auth_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'No Auth Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.no_auth_provider.models['fallback-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String)
+        })
+      }))
+    })
+
+    it('should fall back to OpenCode auth content when resolved providers cannot be loaded', async () => {
+      process.env.OPENCODE_AUTH_CONTENT = JSON.stringify({
+        test_provider: {
+          type: 'api',
+          key: 'auth-store-key'
+        }
+      })
+      mockClient.config.providers.mockRejectedValueOnce(new Error('provider resolution failed'))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'auth-store-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.test_provider.models['auth-store-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer auth-store-key'
+        })
       }))
     })
 


### PR DESCRIPTION
## Summary

Support `/connect`-backed model discovery for custom OpenAI-compatible providers.

Previously, the plugin only used `provider.<id>.options.apiKey` during discovery, so custom providers authenticated through OpenCode `/connect` could not discover protected model endpoints unless the key was duplicated in `opencode.json`.

## Changes

- keep explicit `options.apiKey` as highest-priority discovery credential
- try resolved provider keys from `client.config.providers()` with a short timeout
- fall back to OpenCode-managed auth for same-id `type: "api"` credentials when resolved provider lookup is unavailable
- align auth store path resolution with OpenCode's `xdg-basedir`-based data directory
- add regression tests for auth-backed discovery behavior
- update README and add investigation notes

## Validation

- `npm run test:run`
- `npm run typecheck`

Also verified via `opencode debug config --print-logs --log-level DEBUG` that:

- existing explicit-key providers still discover models
- `test_provider` discovers models after `/connect` without `options.apiKey`