### PR TITLE
refactor(deps): move @opencode-ai/plugin to peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "vitest": "^4.0.16",
       },
       "peerDependencies": {
-        "@opencode-ai/plugin": ">=1.0.0",
+        "@opencode-ai/plugin": ">=1.4.0",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,18 @@
     "": {
       "name": "opencode-model-discovery",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.0.166",
         "xdg-basedir": "^5.1.0",
       },
       "devDependencies": {
+        "@opencode-ai/plugin": "^1.0.166",
         "@types/node": "^25.0.3",
         "@vitest/coverage-v8": "^4.0.16",
         "eslint": "^9.39.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16",
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=1.0.0",
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "opencode": ">=1.4.0"
       },
       "peerDependencies": {
-        "@opencode-ai/plugin": ">=1.0.0"
+        "@opencode-ai/plugin": ">=1.4.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.0.166",
         "xdg-basedir": "^5.1.0"
       },
       "devDependencies": {
+        "@opencode-ai/plugin": "^1.0.166",
         "@types/node": "^25.0.3",
         "@vitest/coverage-v8": "^4.0.16",
         "eslint": "^9.39.2",
@@ -21,6 +21,9 @@
       },
       "engines": {
         "opencode": ">=1.4.0"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -73,13 +76,39 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -295,6 +324,7 @@
     },
     "node_modules/@opencode-ai/plugin": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/sdk": "1.4.1",
@@ -315,6 +345,7 @@
     },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -549,6 +580,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -632,7 +697,6 @@
       "version": "25.5.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -641,7 +705,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.3",
@@ -770,7 +833,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -911,6 +973,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -970,7 +1033,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1294,6 +1356,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -1800,6 +1863,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1819,7 +1883,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1923,6 +1986,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1933,6 +1997,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2067,7 +2132,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2144,7 +2208,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -2231,6 +2294,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2290,6 +2354,7 @@
     },
     "node_modules/zod": {
       "version": "4.1.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "xdg-basedir": "^5.1.0"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.0.0"
+    "@opencode-ai/plugin": ">=1.4.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.0.166",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,13 @@
     "url": "git+https://github.com/yuhp/opencode-models-discovery.git"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.0.166",
     "xdg-basedir": "^5.1.0"
   },
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1.0.0"
+  },
   "devDependencies": {
+    "@opencode-ai/plugin": "^1.0.166",
     "@types/node": "^25.0.3",
     "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.39.2",


### PR DESCRIPTION
## Summary

This PR supersedes and includes #13.

It moves `@opencode-ai/plugin` from runtime dependencies to peer dependencies. OpenCode already provides `@opencode-ai/plugin` as part of the host runtime, so plugin packages should not install their own copy.

## Changes

- Includes #13: move `@opencode-ai/plugin` from `dependencies` to `peerDependencies`
- Keep `@opencode-ai/plugin` in `devDependencies` for local development, typechecking, and tests
- Align the peer dependency range with the existing OpenCode engine requirement:
  - `engines.opencode`: `>=1.4.0`
  - `peerDependencies.@opencode-ai/plugin`: `>=1.4.0`

## Why

OpenCode declares `@opencode-ai/plugin` as a host dependency, so this package should treat it as a host-provided API contract rather than bundling its own runtime dependency.

Using a peer dependency avoids duplicate installations when multiple plugins are used and lets the OpenCode host control the exact plugin API version.

The peer range is narrowed from the original `>=1.0.0` in #13 to `>=1.4.0`, matching this package's existing minimum OpenCode version.

## Validation

- `npm run typecheck`
- `npm run test:run`

## Related

- Closes #13