### PR TITLE
Support host-specific auth stores for Mimocode compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ Discovery auth precedence is:
 
 Details and examples: [`docs/connect-and-auth.md`](docs/connect-and-auth.md)
 
+## Mimocode Compatibility
+
+This plugin is also compatible with Mimocode as an OpenCode-compatible host.
+
+When startup-time discovery needs to recover `/connect`-managed API credentials from the local auth store, the plugin selects the host data directory from runtime environment markers:
+
+- `OPENCODE=1` or no host marker: `~/.local/share/opencode/auth.json`
+- `MIMOCODE=1`: `~/.local/share/mimocode/auth.json`
+
+This keeps the same provider configuration model while allowing the plugin to work in both OpenCode and Mimocode environments.
+
 ## Documentation
 
 - Configuration guide: [`docs/configuration.md`](docs/configuration.md)

--- a/docs/connect-and-auth.md
+++ b/docs/connect-and-auth.md
@@ -35,7 +35,7 @@ Discovery requests resolve credentials in this order:
 
 1. `provider.<name>.options.apiKey`
 2. OpenCode resolved provider key, when available during plugin startup
-3. OpenCode `/connect` auth store for same-id `type: "api"` credentials
+3. Host auth store for same-id `type: "api"` credentials
 
 This preserves existing explicit `apiKey` configs while also allowing custom providers to rely on `/connect` without duplicating secrets in `opencode.json`.
 
@@ -52,5 +52,8 @@ This preserves existing explicit `apiKey` configs while also allowing custom pro
 ## Notes
 
 - OpenCode's provider resolution API can time out inside the `config` hook, so the plugin includes a fallback for `/connect` API-key credentials.
-- That fallback first respects `OPENCODE_AUTH_CONTENT`, then reads the same OpenCode auth store location derived from `xdg-basedir` that OpenCode uses for `Global.Path.data`.
+- That fallback first respects `OPENCODE_AUTH_CONTENT`, then reads a host-specific auth store location derived from `xdg-basedir`.
+- When `OPENCODE=1` is present, the plugin reads `~/.local/share/opencode/auth.json`.
+- When `MIMOCODE=1` is present, the plugin reads `~/.local/share/mimocode/auth.json`.
+- When neither host marker is present, the plugin defaults to `~/.local/share/opencode/auth.json`.
 - The plugin never writes the recovered key back into `opencode.json` and never logs the secret value.

--- a/docs/issues/issue-5-auth-discovery.md
+++ b/docs/issues/issue-5-auth-discovery.md
@@ -23,12 +23,18 @@ Discovery credential resolution now uses this precedence order:
 
 1. `provider.<name>.options.apiKey`
 2. resolved provider credentials from OpenCode, when available quickly enough during startup
-3. a fallback read of the OpenCode auth store for same-id `type: "api"` credentials
+3. a fallback read of the host auth store for same-id `type: "api"` credentials
 
 The fallback read path is:
 
 1. `OPENCODE_AUTH_CONTENT`
-2. OpenCode auth file derived from the same `xdg-basedir` data location OpenCode uses for `Global.Path.data`
+2. Host auth file derived from the same `xdg-basedir` data location used by the active compatible client
+
+The host auth file is selected from runtime environment variables:
+
+- `OPENCODE=1` -> `~/.local/share/opencode/auth.json`
+- `MIMOCODE=1` -> `~/.local/share/mimocode/auth.json`
+- no host marker -> default to `~/.local/share/opencode/auth.json`
 
 This keeps explicit config as the highest-priority source, while allowing `/connect`-managed credentials to work without duplicating secrets in `opencode.json`.
 
@@ -71,6 +77,7 @@ The implementation was validated with:
 - explicit `apiKey` providers still discovering correctly
 - `/connect`-managed custom providers discovering correctly after reconnect/bootstrap
 - fallback behavior through `OPENCODE_AUTH_CONTENT`
+- host-specific auth store reads for OpenCode and Mimocode
 - timeout handling when resolved provider lookup is slow or unavailable
 - test coverage for precedence and failure cases
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-models-discovery",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "OpenCode plugin for auto-discovery of OpenAI-compatible models with dynamic provider configuration",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -31,6 +31,8 @@ interface OpenCodeAuth {
   key?: string
 }
 
+type HostClient = 'opencode' | 'mimocode'
+
 const RESOLVED_PROVIDERS_TIMEOUT_MS = 250
 
 async function getResolvedProvidersByID(
@@ -74,12 +76,25 @@ async function getResolvedProvidersByID(
   }
 }
 
-function getOpenCodeAuthFile(): string | undefined {
+function detectHostClient(): HostClient {
+  if (process.env.OPENCODE === '1') {
+    return 'opencode'
+  }
+
+  if (process.env.MIMOCODE === '1') {
+    return 'mimocode'
+  }
+
+  return 'opencode'
+}
+
+function getHostAuthFile(): string | undefined {
   if (!xdgData) {
     return undefined
   }
 
-  return path.join(xdgData, 'opencode', 'auth.json')
+  const hostClient = detectHostClient()
+  return path.join(xdgData, hostClient, 'auth.json')
 }
 
 async function getOpenCodeAuth(providerName: string, logger: PluginLogger): Promise<OpenCodeAuth | undefined> {
@@ -96,14 +111,14 @@ async function getOpenCodeAuth(providerName: string, logger: PluginLogger): Prom
     })
   }
 
-  const file = getOpenCodeAuthFile()
+  const file = getHostAuthFile()
   if (file) {
     try {
       const auths = JSON.parse(await fs.readFile(file, 'utf8')) as Record<string, OpenCodeAuth>
       return auths[providerName] ?? auths[normalizedProviderName] ?? auths[`${normalizedProviderName}/`]
     } catch (error: any) {
       if (error?.code !== 'ENOENT') {
-        logger.debug('Could not read OpenCode auth store', {
+        logger.debug('Could not read host auth store', {
           error: error instanceof Error ? error.message : String(error),
         })
       }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
 import { ModelDiscoveryPlugin } from '../src/index.ts'
 
 const mockFetch = vi.fn()
@@ -19,6 +20,10 @@ describe('ModelDiscovery Plugin', () => {
   beforeEach(async () => {
     mockFetch.mockClear()
     delete process.env.OPENCODE_AUTH_CONTENT
+    delete process.env.OPENCODE
+    delete process.env.OPENCODE_PID
+    delete process.env.MIMOCODE
+    delete process.env.MIMOCODE_PID
 
     mockClient = {
       app: {
@@ -52,6 +57,10 @@ describe('ModelDiscovery Plugin', () => {
 
   afterEach(() => {
     delete process.env.OPENCODE_AUTH_CONTENT
+    delete process.env.OPENCODE
+    delete process.env.OPENCODE_PID
+    delete process.env.MIMOCODE
+    delete process.env.MIMOCODE_PID
     vi.restoreAllMocks()
   })
 
@@ -342,6 +351,135 @@ describe('ModelDiscovery Plugin', () => {
         method: 'GET',
         headers: expect.objectContaining({
           Authorization: 'Bearer auth-store-key'
+        })
+      }))
+    })
+
+    it('should read the OpenCode host auth store when OPENCODE is set', async () => {
+      process.env.OPENCODE = '1'
+      process.env.OPENCODE_PID = '12345'
+
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({
+        test_provider: {
+          type: 'api',
+          key: 'host-auth-key'
+        }
+      }) as any)
+
+      mockClient.config.providers.mockRejectedValueOnce(new Error('provider resolution failed'))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'host-auth-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(readFileSpy).toHaveBeenCalledWith(expect.stringMatching(/\/opencode\/auth\.json$/), 'utf8')
+      expect(config.provider.test_provider.models['host-auth-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer host-auth-key'
+        })
+      }))
+    })
+
+    it('should default to the OpenCode host auth store when no host env is set', async () => {
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({
+        test_provider: {
+          type: 'api',
+          key: 'default-host-auth-key'
+        }
+      }) as any)
+
+      mockClient.config.providers.mockRejectedValueOnce(new Error('provider resolution failed'))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'default-host-auth-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(readFileSpy).toHaveBeenCalledWith(expect.stringMatching(/\/opencode\/auth\.json$/), 'utf8')
+      expect(config.provider.test_provider.models['default-host-auth-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer default-host-auth-key'
+        })
+      }))
+    })
+
+    it('should read the Mimocode host auth store when MIMOCODE is set', async () => {
+      process.env.MIMOCODE = '1'
+      process.env.MIMOCODE_PID = '67890'
+
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({
+        test_provider: {
+          type: 'api',
+          key: 'mimo-auth-key'
+        }
+      }) as any)
+
+      mockClient.config.providers.mockRejectedValueOnce(new Error('provider resolution failed'))
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mimo-auth-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          test_provider: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Test Provider',
+            options: { baseURL: 'http://127.0.0.1:4000/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(readFileSpy).toHaveBeenCalledWith(expect.stringMatching(/\/mimocode\/auth\.json$/), 'utf8')
+      expect(config.provider.test_provider.models['mimo-auth-model']).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:4000/v1/models', expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mimo-auth-key'
         })
       }))
     })


### PR DESCRIPTION
## Summary

This PR adds Mimocode compatibility for startup-time auth-backed model discovery.

Instead of always reading `~/.local/share/opencode/auth.json`, the plugin now selects the auth store based on host runtime environment markers:

- `OPENCODE=1` -> `~/.local/share/opencode/auth.json`
- `MIMOCODE=1` -> `~/.local/share/mimocode/auth.json`
- no host marker -> default to `~/.local/share/opencode/auth.json`

This keeps the existing auth precedence unchanged:

1. `provider.<name>.options.apiKey`
2. resolved provider key from OpenCode
3. `OPENCODE_AUTH_CONTENT`
4. host-specific local auth store

## Changes

- add host detection for `opencode` and `mimocode`
- switch auth file resolution to host-specific paths
- keep OpenCode as the default host when no marker is present
- add tests for:
  - `OPENCODE=1`
  - `MIMOCODE=1`
  - default OpenCode fallback
- update docs and README with Mimocode compatibility notes

## Validation

- `npm run test:run`
- `npm run typecheck`

Both passed locally.

## Why

Mimocode stores compatible auth data under a different XDG data directory than OpenCode.  
The auth format is compatible, but the previous implementation hardcoded the OpenCode path, which prevented startup discovery from reusing `/connect`-managed credentials in Mimocode.