### PR TITLE
feat: add models.dev fallback with comprehensive metadata enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ opencode-debug.log
 .cache/
 coverage/
 opencode.json
+.omo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.10.0",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "xdg-basedir": "^5.1.0"

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -6,6 +6,7 @@ import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, autoDetectOpenAICompatibleProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
 import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
+import { fetchModelsDevData } from '../utils/models-dev-fetcher'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
 import type { OpenAIModel } from '../types'
@@ -172,6 +173,11 @@ export async function enhanceConfig(
   logger: PluginLogger
 ): Promise<void> {
   try {
+    const modelsDevCache = await fetchModelsDevData()
+    logger.info('Loaded models.dev data', {
+      count: modelsDevCache.size
+    })
+
     const providers = config.provider || {}
     const openAICompatibleProviders: DiscoveredProvider[] = []
     const providerFilter = getProviderFilter(pluginConfig)
@@ -235,7 +241,7 @@ export async function enhanceConfig(
       } else if (typeof modelInfoEndpoint === 'string' && modelInfoEndpoint.length > 0 && modelInfoFormat) {
         const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)
         if (modelInfoDiscovery.ok) {
-          modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, modelInfoDiscovery.data, { filterNonChat })
+          modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, modelInfoDiscovery.data, { filterNonChat, modelsDevCache })
         } else {
           logger.warn('Provider model info discovery failed', {
             provider: providerName,

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -1,5 +1,6 @@
 import type { LiteLLMModelInfo, LiteLLMModelInfoEntry } from '../../types'
 import type { ModelInfoEnricher, ModelInfoEnricherOptions } from './types'
+import { lookupModelsDevData, type ModelsDevModel } from '../models-dev-fetcher'
 
 function hasUsableNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
@@ -70,24 +71,45 @@ function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | 
   return Object.keys(variants).length > 0 ? variants : undefined
 }
 
-function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
+function applyLiteLLMModelInfo(
+  modelConfig: any, 
+  entry: LiteLLMModelInfoEntry | undefined,
+  modelsDevCache?: Map<string, ModelsDevModel>
+): void {
   const info = entry?.model_info
   if (!info) return
 
   const DEFAULT_CONTEXT = 200000
   const DEFAULT_OUTPUT = 32000
 
-  const contextLimit = hasUsableNumber(info.max_input_tokens) 
+  let contextLimit = hasUsableNumber(info.max_input_tokens) 
     ? info.max_input_tokens 
     : hasUsableNumber(info.max_tokens)
       ? info.max_tokens
-      : DEFAULT_CONTEXT
+      : undefined
 
-  const outputLimit = hasUsableNumber(info.max_output_tokens) 
+  let outputLimit = hasUsableNumber(info.max_output_tokens) 
     ? info.max_output_tokens 
     : hasUsableNumber(info.max_tokens)
       ? info.max_tokens
-      : DEFAULT_OUTPUT
+      : undefined
+
+  // Fallback to models.dev
+  if ((!hasUsableNumber(contextLimit) || !hasUsableNumber(outputLimit)) && modelsDevCache) {
+    const modelsDevData = lookupModelsDevData(modelConfig.id, modelsDevCache)
+    if (modelsDevData?.limit) {
+      if (!hasUsableNumber(contextLimit)) {
+        contextLimit = modelsDevData.limit.context || modelsDevData.limit.input
+      }
+      if (!hasUsableNumber(outputLimit)) {
+        outputLimit = modelsDevData.limit.output
+      }
+    }
+  }
+
+  // Final fallback to default
+  contextLimit = hasUsableNumber(contextLimit) ? contextLimit : DEFAULT_CONTEXT
+  outputLimit = hasUsableNumber(outputLimit) ? outputLimit : DEFAULT_OUTPUT
 
   modelConfig.limit = {
     context: contextLimit,
@@ -123,7 +145,11 @@ export function createLiteLLMModelInfoEnricher(
       return typeof mode === 'string' && mode.length > 0 && mode !== 'chat'
     },
     applyModelInfo(modelConfig: any, modelId: string): void {
-      applyLiteLLMModelInfo(modelConfig, getModelInfo(modelInfoById, modelId))
+      applyLiteLLMModelInfo(
+        modelConfig, 
+        getModelInfo(modelInfoById, modelId),
+        options.modelsDevCache
+      )
     },
   }
 }

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -74,14 +74,25 @@ function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | 
   const info = entry?.model_info
   if (!info) return
 
-  const contextLimit = hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : info.max_tokens
-  const outputLimit = hasUsableNumber(info.max_output_tokens) ? info.max_output_tokens : info.max_tokens
-  if (hasUsableNumber(contextLimit) && hasUsableNumber(outputLimit)) {
-    modelConfig.limit = {
-      context: contextLimit,
-      input: hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : undefined,
-      output: outputLimit,
-    }
+  const DEFAULT_CONTEXT = 200000
+  const DEFAULT_OUTPUT = 32000
+
+  const contextLimit = hasUsableNumber(info.max_input_tokens) 
+    ? info.max_input_tokens 
+    : hasUsableNumber(info.max_tokens)
+      ? info.max_tokens
+      : DEFAULT_CONTEXT
+
+  const outputLimit = hasUsableNumber(info.max_output_tokens) 
+    ? info.max_output_tokens 
+    : hasUsableNumber(info.max_tokens)
+      ? info.max_tokens
+      : DEFAULT_OUTPUT
+
+  modelConfig.limit = {
+    context: contextLimit,
+    input: hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : undefined,
+    output: outputLimit,
   }
 
   if (info.supports_reasoning === true) {

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -94,20 +94,20 @@ function applyLiteLLMModelInfo(
       ? info.max_tokens
       : undefined
 
-  // Fallback to models.dev
-  if ((!hasUsableNumber(contextLimit) || !hasUsableNumber(outputLimit)) && modelsDevCache) {
-    const modelsDevData = lookupModelsDevData(modelConfig.id, modelsDevCache)
-    if (modelsDevData?.limit) {
-      if (!hasUsableNumber(contextLimit)) {
-        contextLimit = modelsDevData.limit.context || modelsDevData.limit.input
-      }
-      if (!hasUsableNumber(outputLimit)) {
-        outputLimit = modelsDevData.limit.output
-      }
+  let modelsDevData: ModelsDevModel | undefined
+  if (modelsDevCache) {
+    modelsDevData = lookupModelsDevData(modelConfig.id, modelsDevCache)
+  }
+
+  if ((!hasUsableNumber(contextLimit) || !hasUsableNumber(outputLimit)) && modelsDevData?.limit) {
+    if (!hasUsableNumber(contextLimit)) {
+      contextLimit = modelsDevData.limit.context || modelsDevData.limit.input
+    }
+    if (!hasUsableNumber(outputLimit)) {
+      outputLimit = modelsDevData.limit.output
     }
   }
 
-  // Final fallback to default
   contextLimit = hasUsableNumber(contextLimit) ? contextLimit : DEFAULT_CONTEXT
   outputLimit = hasUsableNumber(outputLimit) ? outputLimit : DEFAULT_OUTPUT
 
@@ -119,11 +119,55 @@ function applyLiteLLMModelInfo(
 
   if (info.supports_reasoning === true) {
     modelConfig.reasoning = true
+  } else if (modelsDevData?.reasoning !== undefined) {
+    modelConfig.reasoning = modelsDevData.reasoning
   }
 
   const variants = createReasoningVariants(info)
   if (variants) {
     modelConfig.variants = variants
+  }
+
+  if (modelsDevData) {
+    if (modelsDevData.family !== undefined) {
+      modelConfig.family = modelsDevData.family
+    }
+    if (modelsDevData.attachment !== undefined) {
+      modelConfig.attachment = modelsDevData.attachment
+    }
+    if (modelsDevData.tool_call !== undefined) {
+      modelConfig.tool_call = modelsDevData.tool_call
+    }
+    if (modelsDevData.structured_output !== undefined) {
+      modelConfig.structured_output = modelsDevData.structured_output
+    }
+    if (modelsDevData.temperature !== undefined) {
+      modelConfig.temperature = modelsDevData.temperature
+    }
+    if (modelsDevData.knowledge !== undefined && modelsDevData.knowledge !== null) {
+      modelConfig.knowledge = modelsDevData.knowledge
+    }
+    if (modelsDevData.release_date !== undefined) {
+      modelConfig.release_date = modelsDevData.release_date
+    }
+    if (modelsDevData.last_updated !== undefined) {
+      modelConfig.last_updated = modelsDevData.last_updated
+    }
+    if (modelsDevData.modalities !== undefined) {
+      modelConfig.modalities = modelsDevData.modalities
+    }
+    if (modelsDevData.open_weights !== undefined) {
+      modelConfig.open_weights = modelsDevData.open_weights
+    }
+    if (modelsDevData.weights !== undefined && modelsDevData.weights !== null) {
+      modelConfig.weights = modelsDevData.weights
+    }
+    if (modelsDevData.benchmarks !== undefined && modelsDevData.benchmarks !== null) {
+      modelConfig.benchmarks = modelsDevData.benchmarks
+    }
+    if (modelsDevData.pricing !== undefined && modelsDevData.pricing !== null) {
+      modelConfig.pricing = modelsDevData.pricing
+    }
   }
 }
 

--- a/src/utils/model-info/types.ts
+++ b/src/utils/model-info/types.ts
@@ -1,3 +1,5 @@
+import type { ModelsDevModel } from '../models-dev-fetcher'
+
 export interface ModelInfoEnricher {
   shouldSkipModel(modelId: string): boolean
   applyModelInfo(modelConfig: any, modelId: string): void
@@ -5,4 +7,5 @@ export interface ModelInfoEnricher {
 
 export interface ModelInfoEnricherOptions {
   filterNonChat: boolean
+  modelsDevCache?: Map<string, ModelsDevModel>
 }

--- a/src/utils/models-dev-fetcher.ts
+++ b/src/utils/models-dev-fetcher.ts
@@ -1,6 +1,36 @@
 interface ModelsDevModel {
   id: string
   name?: string
+  family?: string
+  attachment?: boolean
+  reasoning?: boolean
+  tool_call?: boolean
+  structured_output?: boolean
+  temperature?: boolean
+  knowledge?: string | null
+  release_date?: string
+  last_updated?: string
+  modalities?: {
+    input?: string[]
+    output?: string[]
+  }
+  open_weights?: boolean
+  weights?: Array<{
+    label: string
+    url: string
+  }> | null
+  benchmarks?: Array<{
+    name: string
+    score: number
+    metric: string
+    harness?: string
+    source: string
+  }> | null
+  pricing?: {
+    input?: number
+    output?: number
+    currency?: string
+  } | null
   limit?: {
     context?: number
     input?: number

--- a/src/utils/models-dev-fetcher.ts
+++ b/src/utils/models-dev-fetcher.ts
@@ -1,0 +1,80 @@
+interface ModelsDevModel {
+  id: string
+  name?: string
+  limit?: {
+    context?: number
+    input?: number
+    output?: number
+  }
+}
+
+let modelsDevCache: Map<string, ModelsDevModel> | null = null
+
+export async function fetchModelsDevData(): Promise<Map<string, ModelsDevModel>> {
+  if (modelsDevCache) return modelsDevCache
+
+  try {
+    const response = await (globalThis as any).fetch('https://models.dev/models.json')
+
+    if (!response.ok) {
+      return new Map()
+    }
+
+    const data = await response.json() as Record<string, ModelsDevModel>
+    
+    modelsDevCache = new Map()
+    for (const [, model] of Object.entries(data)) {
+      if (model.id) {
+        modelsDevCache.set(model.id, model)
+      }
+    }
+
+    return modelsDevCache
+  } catch {
+    return new Map()
+  }
+}
+
+export function lookupModelsDevData(
+  modelId: string,
+  cache: Map<string, ModelsDevModel>
+): ModelsDevModel | undefined {
+  
+  // Level 1: Exact match
+  if (cache.has(modelId)) return cache.get(modelId)
+  
+  // Parse LiteLLM model ID
+  const parts = modelId.split('/')
+  const litellmProvider = parts.length > 1 ? parts[0] : null
+  const litellmModel = parts.length > 1 ? parts[1] : parts[0]
+  
+  // Level 2: Provider + Model match
+  if (litellmProvider) {
+    for (const [key, value] of cache.entries()) {
+      const devParts = key.split('/')
+      if (devParts.length > 1) {
+        const devProvider = devParts[0]
+        const devModel = devParts[1]
+        
+        if (devProvider === litellmProvider && devModel === litellmModel) {
+          return value
+        }
+      }
+    }
+  }
+  
+  // Level 3: Model name only (ignore provider)
+  const modelNameLower = litellmModel.toLowerCase()
+  
+  for (const [key, value] of cache.entries()) {
+    const devModel = key.split('/').pop()!.toLowerCase()
+    
+    if (modelNameLower === devModel) {
+      return value
+    }
+  }
+  
+  return undefined
+}
+
+export type { ModelsDevModel }


### PR DESCRIPTION
## Summary

Adds models.dev as a fallback data source for model metadata when LiteLLM API data is missing or incomplete. Implements 3-level exact matching strategy and enriches model configs with comprehensive metadata including capabilities, modalities, benchmarks, and pricing.

## Why

- LiteLLM API doesn't always provide complete model metadata (limits, capabilities)
- Many models lack context/output token limits, causing plugin to use arbitrary defaults
- Missing metadata prevents OpenCode from making informed model selection decisions
- models.dev provides comprehensive, up-to-date model information for450+ models

## Changes

- **3-level matching**: Exact ID → Provider+Model → Model name only (handles prefix mismatches like `gemini/` vs `google/`)
- **Default fallback values**: 200K context, 32K output (previously undefined)
- **Comprehensive metadata**: family, attachment, tool_call, structured_output, temperature, knowledge, release_date, modalities, open_weights, weights, benchmarks, pricing
- **Fallback chain**: LiteLLM API → models.dev → defaults (200K/32K)
- **Startup fetch**: models.dev data loaded once at plugin initialization

## Testing

1. Configure provider with discovery enabled:
   ```json
   {
     "provider": {
       "sumopod": {
         "options": {
           "baseURL": "https://ai.sumopod.com",
           "modelsDiscovery": {
             "enabled": true,
             "modelInfoEndpoint": "/v1/model/info",
             "modelInfoFormat": "litellm"
           }
         }
       }
     }
   }
   ```

3. Verify in logs:
   - `[opencode-models-discovery] Loaded models.dev data { count: 450 }`
   - Models without LiteLLM data should have limits from models.dev
   - Models with neither should have200K/32K defaults

4. Check model config includes new fields: `family`, `attachment`, `tool_call`, `modalities`, etc.