### PR TITLE
V1.0.0 provider level config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ opencode-debug.log
 .cache/
 coverage/
 opencode.json
+docs/articles/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Originally inspired by [opencode-lmstudio](https://github.com/nicktasios/opencod
 - Works with any OpenAI-compatible provider
 - Discovers models dynamically from provider model endpoints
 - Injects discovered models into OpenCode provider config automatically
-- Supports provider-level include, exclude, and endpoint overrides
-- Supports regex-based model filtering
+- Supports provider-level enablement, endpoint overrides, and model filters
+- Supports regex-based model id filtering and raw provider field equality filtering
 - Can enrich model limits and reasoning metadata from provider-specific endpoints
 - Supports OpenCode `/connect` credentials for custom providers
 
@@ -55,9 +55,11 @@ Add the plugin to your `opencode.json`:
 
 On startup, the plugin will query the provider's models endpoint and merge discovered models into the active OpenCode config.
 
-## v0.12 Transition and v1.0 Compatibility
+## v1.0 Configuration Boundary
 
-Version `0.12.x` is a transition line for the next configuration model. Existing plugin-level discovery options continue to work in `0.12.x`, but they are deprecated and will be removed in `1.0.0`.
+Version `1.0.0` uses provider-level discovery configuration only. Put discovery settings under `provider.<id>.options.modelsDiscovery`.
+
+Plugin-level global discovery options are still detected for migration help, but they are no longer applied at runtime:
 
 Deprecated plugin-level options:
 
@@ -68,7 +70,7 @@ Deprecated plugin-level options:
 - `models.excludeRegex`
 - `smartModelName`
 
-Recommended configuration should live on each provider instead:
+Configuration should live on each provider instead:
 
 ```json
 {
@@ -78,8 +80,13 @@ Recommended configuration should live on each provider instead:
         "modelsDiscovery": {
           "enabled": true,
           "models": {
-            "includeRegex": "^llama",
-            "excludeRegex": "embedding"
+            "includeBy": [
+              { "field": "id", "match": "^llama" }
+            ],
+            "excludeBy": [
+              { "field": "available", "equals": false },
+              { "field": "id", "match": "embedding" }
+            ]
           },
           "smartModelName": true,
           "modelInfoFormat": "models.dev"
@@ -90,16 +97,16 @@ Recommended configuration should live on each provider instead:
 }
 ```
 
-Only add the fields you need. For example, do not add regex filters unless you actually want filtering.
+Only add the fields you need. For example, do not add filters unless you actually want filtering.
 
-Planned `1.0.0` behavior:
-
-- Plugin-level global discovery config will be removed.
-- Discovery will remain enabled by default for providers unless disabled.
+- Discovery remains enabled by default for providers unless disabled.
 - Set `provider.<id>.options.modelsDiscovery.enabled = false` to disable discovery for one provider.
-- A future `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false` environment variable is planned for users who want unspecified providers to default to disabled.
+- Set `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false` to make providers without explicit `modelsDiscovery.enabled` default to disabled.
+- Explicit provider-level `modelsDiscovery.enabled` always wins over the environment default.
 
-When `0.12.x` detects deprecated global config, it logs a warning, shows a migration toast, and injects `/models-discovery:migrate` into OpenCode commands.
+When legacy global config is detected, the plugin logs a warning, shows a migration toast, and injects `/models-discovery:migrate` into OpenCode commands.
+
+Prefer `models.includeBy` and `models.excludeBy` for model filtering. They filter top-level raw fields returned by a provider's `/v1/models` response. Each field rule uses either `equals` for strict equality or `match` for regex matching against string field values. Use `{ "field": "id", "match": "..." }` for id/name regex filtering. `includeBy` and `excludeBy` are cumulative, and `excludeBy` wins over `includeBy`. `models.includeRegex` and `models.excludeRegex` are retained as legacy id-only shortcuts; when `includeRegex` is configured, `excludeRegex` is not applied. Provider-specific fields such as `available` are not part of the generic OpenAI-compatible contract, so configure these filters only when your provider returns those fields.
 
 ## Helper Commands
 
@@ -113,9 +120,9 @@ This command is available whenever the plugin is loaded.
 
 ### `/models-discovery:migrate`
 
-Opens an assistant-guided migration flow using OpenCode's `customize-opencode` skill. It looks for OpenCode config files that declare this plugin and moves deprecated plugin-level discovery options into `provider.<id>.options.modelsDiscovery` where safe.
+Opens an assistant-guided migration flow using OpenCode's `customize-opencode` skill. It looks for OpenCode config files that declare this plugin and moves legacy plugin-level discovery options into `provider.<id>.options.modelsDiscovery` where safe.
 
-This command is injected only when deprecated global discovery config is detected.
+This command is injected only when legacy global discovery config is detected.
 
 The migration assistant is instructed to inspect project config, user global config, and `OPENCODE_CONFIG` when present. It should not edit managed or organization-controlled config unless you explicitly ask it to.
 
@@ -187,6 +194,7 @@ This keeps the same provider configuration model while allowing the plugin to wo
 
 - Configuration guide: [`docs/configuration.md`](docs/configuration.md)
 - `/connect` credentials and auth-backed discovery: [`docs/connect-and-auth.md`](docs/connect-and-auth.md)
+- Community provider examples: [`docs/config_example/`](docs/config_example/)
 - Provider compatibility and detection rules: [`docs/providers.md`](docs/providers.md)
 - Upgrade notes: [`docs/upgrading.md`](docs/upgrading.md)
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "xdg-basedir": "^5.1.0",
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.0.166",
+        "@opencode-ai/plugin": "^1.17.10",
         "@types/node": "^25.0.3",
         "@vitest/coverage-v8": "^4.0.16",
         "eslint": "^9.39.2",
@@ -21,6 +21,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -69,11 +71,23 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.4.1", "", { "dependencies": { "@opencode-ai/sdk": "1.4.1", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.1.97", "@opentui/solid": ">=0.1.97" }, "optionalPeers": ["@opentui/core", "@opentui/solid"] }, "sha512-5PqQGUAVeNPNM6PyQATSe5q7ICwFSIFYEMFHzD6Efw2fSd1ij5vskgtxEZFl/oiXkPx/w8/DPR9EZS9bkoHYnA=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.11", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.17.11", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-mE6SR1tVxL98zbZrlneqF/+dpIKLeZHKzWZy35Hq54uEnuCM1gKq3LK8F2PG2zMBDKQtz2fahEIksJ7svoPLLw=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.1", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-7wWHs8Og5W5+fuJmHDi7oy1yK6c9mmVfK1Ll9hPHZZ5xj357fVl+oI4i0jeUdjonEoXb3Svq/U5blraSArX5OQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.11", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
@@ -179,6 +193,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "effect": ["effect@4.0.0-beta.83", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -203,6 +219,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
@@ -212,6 +230,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -235,6 +255,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -253,11 +275,15 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -299,9 +325,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -328,6 +362,8 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -359,6 +395,8 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -368,6 +406,8 @@
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
@@ -380,6 +420,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/docs/config_example/README.md
+++ b/docs/config_example/README.md
@@ -1,0 +1,19 @@
+# Community Provider Configuration Examples
+
+This directory contains community-maintained provider configuration examples for `opencode-models-discovery`.
+
+Examples may include provider declarations, non-standard `modelsDiscovery.endpoint` values, provider-level `models.includeBy` and `models.excludeBy` raw-field filters using `equals` or `match`, metadata enrichment options, and notes about provider-specific behavior. Provider-level `models.includeRegex` and `models.excludeRegex` are supported as id-only shortcuts, but examples should prefer `includeBy` and `excludeBy`.
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by the providers listed in these examples.
+
+Examples are community-maintained and may become outdated. Users are responsible for verifying provider legality, terms of service, pricing, data handling, and regional availability.
+
+Examples are not security, legal, compliance, or purchasing advice.
+
+Do not paste secrets into public issues or pull requests. Configure provider credentials with OpenCode `/connect` when possible, or through local private config.
+
+## Examples
+
+- [DeepSeek](deepseek.md)

--- a/docs/config_example/deepseek.md
+++ b/docs/config_example/deepseek.md
@@ -1,0 +1,32 @@
+# DeepSeek Configuration Example
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by DeepSeek.
+
+## Example
+
+```json
+{
+  "provider": {
+    "deepseek": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "DeepSeek",
+      "options": {
+        "baseURL": "https://api.deepseek.com/",
+        "modelsDiscovery": {
+          "endpoint": "/models",
+          "modelInfoFormat": "models.dev"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Notes
+
+- Configure credentials with OpenCode `/connect` when possible.
+- The DeepSeek model list endpoint is `/models` relative to `https://api.deepseek.com/`.
+- Verify the provider's current API base URL, model endpoint, and terms before use.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 This plugin discovers models for OpenAI-compatible providers and merges them into the active OpenCode config at startup.
 
-For new setups, use `provider.<name>.options.modelsDiscovery` for provider-specific behavior. This keeps discovery rules close to the provider they affect and avoids older global rules unintentionally changing newer providers.
+Use `provider.<name>.options.modelsDiscovery` for provider-specific behavior. This is the only supported configuration boundary in `1.0.0`.
 
 OpenCode's own provider config still controls provider identity, npm package, `baseURL`, credentials, and provider availability. This plugin controls model discovery for providers that OpenCode has made available.
 
@@ -22,7 +22,9 @@ Each provider can configure discovery behavior through `provider.<name>.options.
         "modelsDiscovery": {
           "enabled": true,
           "models": {
-            "includeRegex": ["^llama"]
+            "includeBy": [
+              { "field": "id", "match": "^llama" }
+            ]
           },
           "smartModelName": true
         }
@@ -39,8 +41,10 @@ Each provider can configure discovery behavior through `provider.<name>.options.
 | `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Provider-specific model info endpoint path. Metadata enrichment is disabled when omitted |
 | `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"litellm"` and `"models.dev"` |
 | `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true` |
-| `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Provider-specific model include filter |
-| `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Provider-specific model exclude filter |
+| `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Shortcut regex allow-list for discovered model ids only |
+| `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Shortcut regex deny-list for discovered model ids only |
+| `provider.<name>.options.modelsDiscovery.models.includeBy` | `{ field: string, equals: string \| number \| boolean \| null }[]` or `{ field: string, match: string }[]` | Allow-list for top-level raw provider model fields |
+| `provider.<name>.options.modelsDiscovery.models.excludeBy` | `{ field: string, equals: string \| number \| boolean \| null }[]` or `{ field: string, match: string }[]` | Deny-list for top-level raw provider model fields |
 | `provider.<name>.options.modelsDiscovery.smartModelName` | `boolean` | Use human-friendly display names instead of raw discovered model ids |
 
 Recommended approach:
@@ -52,17 +56,75 @@ Recommended approach:
 
 If `provider.<name>.options.modelsDiscovery.endpoint` is omitted, the plugin uses `/v1/models`.
 
-## Priority Rules
+## Default Enablement
 
 1. `provider.<name>.options.modelsDiscovery.enabled = true` forces discovery for that provider.
 2. `provider.<name>.options.modelsDiscovery.enabled = false` disables discovery for that provider.
-3. If `enabled` is omitted, discovery follows the plugin default and compatibility detection.
-4. If a provider defines `modelsDiscovery.models` filters, those filters apply only to that provider.
+3. If `enabled` is omitted, `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED` controls the default when set.
+4. If the environment variable is omitted or invalid, the built-in default is `true`.
 5. OpenCode `enabled_providers` and `disabled_providers` control whether providers are available at all. This plugin does not override those OpenCode provider availability settings.
 
-## v0.12 Transition and v1.0 Compatibility
+Accepted false values are `false`, `0`, `no`, and `off`. Accepted true values are `true`, `1`, `yes`, and `on`. Invalid values warn and fall back to `true`.
 
-Version `0.12.x` still supports legacy plugin-level discovery configuration for compatibility, but new configuration should be provider-level. Plugin-level discovery options are planned for removal in `1.0.0`.
+## Model Filters
+
+Provider-level filters live under `provider.<name>.options.modelsDiscovery.models`.
+
+Prefer `includeBy` and `excludeBy` for model filtering. They work for `id` and for other top-level raw fields returned in the provider's `/v1/models` response.
+
+Use `includeBy` or `excludeBy` with `field: "id"` and `match` when filtering model ids by regex. This is the recommended form for new config.
+
+`includeRegex` and `excludeRegex` are retained as shortcuts for id-only regex filtering. They are regular expressions evaluated against the discovered model id and cannot filter non-id fields.
+
+Use `includeBy` and `excludeBy` when filtering by top-level fields returned in the provider's raw `/v1/models` response. Each rule must include exactly one of:
+
+- `equals`: strict equality against `string`, `number`, `boolean`, or `null` field values
+- `match`: regular expression matching against string field values
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "excludeBy": [
+        { "field": "available", "equals": false },
+        { "field": "id", "match": "embedding" }
+      ],
+      "includeBy": [
+        { "field": "id", "match": "^deepseek" }
+      ]
+    }
+  }
+}
+```
+
+`includeBy` keeps a model when it matches at least one rule. `excludeBy` removes a model when it matches any rule, and exclusion wins when both include and exclude rules match. Missing fields do not match. Nested paths, type coercion, arrays, and objects are not supported.
+
+`includeBy` and `excludeBy` can replace `includeRegex` and `excludeRegex` for id filtering by using `field: "id"` with `match`.
+
+### Filter Order And Combination
+
+`includeBy` and `excludeBy` are cumulative. A model must pass `includeBy` first, then `excludeBy`, before it can be injected.
+
+Recommended field-filter order is:
+
+1. `includeBy`
+2. `excludeBy`
+
+Within that order:
+
+- `includeBy` is an allow-list: when configured, a model must match at least one rule.
+- `excludeBy` is a deny-list: when a model matches any rule, it is removed.
+- `excludeBy` wins over `includeBy` when both match the same model.
+
+`includeRegex` and `excludeRegex` are retained as legacy id-only shortcuts. They are not fully cumulative with each other: when `includeRegex` is configured, the model id only needs to match `includeRegex`, and `excludeRegex` is not applied. `excludeRegex` is applied only when `includeRegex` is not configured.
+
+Prefer `includeBy` and `excludeBy` with `field: "id"` and `match` when you need both allow-list and deny-list regex behavior for model ids.
+
+Provider-specific raw fields such as `available` are not part of the generic OpenAI-compatible model list contract. The plugin does not hardcode provider-specific behavior; use `includeBy` or `excludeBy` only when your provider returns the field.
+
+## Legacy Global Config
+
+Version `1.0.0` ignores legacy plugin-level discovery configuration at runtime. It still detects legacy config so users can migrate.
 
 Legacy plugin-level options:
 
@@ -73,16 +135,11 @@ Legacy plugin-level options:
 - `models.excludeRegex`
 - `smartModelName`
 
-When deprecated global config is detected, `0.12.x` logs a warning, shows a toast, and injects `/models-discovery:migrate` to guide migration.
+When legacy global config is detected, the plugin logs a warning, shows a toast, and injects `/models-discovery:migrate` to guide migration. The legacy fields do not change discovery behavior.
 
-Planned `1.0.0` behavior:
+Use `/models-discovery:config` for assistant-guided provider-level setup. Use `/models-discovery:migrate` when legacy plugin-level config is detected.
 
-- Plugin-level discovery config is removed.
-- Discovery remains enabled by default for compatible providers.
-- `provider.<name>.options.modelsDiscovery.enabled = false` disables discovery for a specific provider.
-- `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false` is planned for users who want providers without explicit config to default to disabled.
-
-Use `/models-discovery:config` for assistant-guided provider-level setup. Use `/models-discovery:migrate` when `0.12.x` detects deprecated plugin-level config.
+Community provider examples live in [`docs/config_example/`](config_example/).
 
 ## Model Metadata Enrichment
 
@@ -217,7 +274,9 @@ For providers with custom metadata paths or non-standard behavior:
           "enabled": true,
           "endpoint": "/v1/models",
           "models": {
-            "includeRegex": ["^gpt-"]
+            "includeBy": [
+              { "field": "id", "match": "^gpt-" }
+            ]
           },
           "smartModelName": true
         }
@@ -245,7 +304,7 @@ For providers with custom metadata paths or non-standard behavior:
 In this example:
 
 1. `lmstudio` explicitly enables discovery and uses the default `/v1/models` endpoint.
-2. `lmstudio` limits discovery to models matching `^gpt-`.
+2. `lmstudio` limits discovery to model ids matching `^gpt-` with `includeBy`.
 3. `deepseek` explicitly enables discovery but uses `"/models"` instead of `/v1/models`.
 4. The API key uses an example placeholder and should be replaced in real configs.
 
@@ -264,7 +323,9 @@ In this example:
         "modelsDiscovery": {
           "enabled": true,
           "models": {
-            "includeRegex": ["^qwen/"]
+            "includeBy": [
+              { "field": "id", "match": "^qwen/" }
+            ]
           }
         }
       }
@@ -318,7 +379,7 @@ For new configs, enable or disable discovery on the provider itself:
 }
 ```
 
-Legacy plugin-level provider filters are still supported in `0.12.x`, but are deprecated:
+Legacy plugin-level provider filters are ignored in `1.0.0` and are shown here only to help identify config that should be migrated:
 
 | Option | Type | Description |
 |--------|------|-------------|
@@ -338,16 +399,18 @@ Legacy plugin-level provider filters are still supported in `0.12.x`, but are de
 }
 ```
 
-## Model Filtering
+## Model Filtering Reference
 
-Control which discovered models are auto-injected with provider-level regular expressions:
+Control which discovered models are auto-injected with provider-level field filters:
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | If non-empty, only discovered model ids matching at least one regex will be added for this provider |
-| `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Discovered model ids matching any regex will be skipped for this provider |
+| `provider.<name>.options.modelsDiscovery.models.includeBy` | `{ field: string, equals: string \| number \| boolean \| null }[]` or `{ field: string, match: string }[]` | If non-empty, only discovered models matching at least one rule will be added for this provider |
+| `provider.<name>.options.modelsDiscovery.models.excludeBy` | `{ field: string, equals: string \| number \| boolean \| null }[]` or `{ field: string, match: string }[]` | Discovered models matching any rule will be skipped for this provider |
+| `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Id-only shortcut for `includeBy` with `field: "id"` and `match` |
+| `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Id-only shortcut for `excludeBy` with `field: "id"` and `match` |
 
-Regex filtering only applies to auto-discovered models. Models already explicitly configured by the user are preserved.
+Filtering only applies to auto-discovered models. Models already explicitly configured by the user are preserved.
 
 ```json
 {
@@ -356,8 +419,12 @@ Regex filtering only applies to auto-discovered models. Models already explicitl
       "options": {
         "modelsDiscovery": {
           "models": {
-            "includeRegex": ["^qwen/", "gpt-4"],
-            "excludeRegex": ["embedding", "test"]
+            "includeBy": [
+              { "field": "id", "match": "^qwen/|gpt-4" }
+            ],
+            "excludeBy": [
+              { "field": "id", "match": "embedding|test" }
+            ]
           }
         }
       }
@@ -366,4 +433,4 @@ Regex filtering only applies to auto-discovered models. Models already explicitl
 }
 ```
 
-Legacy plugin-level model filters are still supported in `0.12.x`, but are deprecated.
+Legacy plugin-level model filters are ignored in `1.0.0`. Move them to `provider.<name>.options.modelsDiscovery.models` when you still need those filters. Prefer migrating regex id filters to `includeBy`/`excludeBy` rules using `field: "id"` and `match`; provider-level `includeRegex`/`excludeRegex` remain available as id-only shortcuts.

--- a/docs/issues/v1.0.0-provider-level-config-prd.md
+++ b/docs/issues/v1.0.0-provider-level-config-prd.md
@@ -1,0 +1,463 @@
+# v1.0.0: Provider-Level Configuration PRD
+
+## Goal
+
+Version `1.0.0` should complete the provider-level configuration migration started in `0.12.0`.
+
+The plugin should remove support for plugin-level global discovery configuration while keeping model discovery, metadata enrichment, provider-level filtering, command helpers, and migration guidance available.
+
+The core configuration boundary after `1.0.0` is:
+
+```text
+provider.<id>.options.modelsDiscovery
+```
+
+## Non-Goals
+
+- Do not remove or weaken provider-level `modelsDiscovery` configuration.
+- Do not remove model discovery itself.
+- Do not remove metadata enrichment support such as LiteLLM or models.dev enrichment.
+- Do not remove provider-level `models.includeRegex` or `models.excludeRegex` filters.
+- Do not introduce provider-specific built-in behavior for fields such as `available`.
+- Do not make this project an endorsement layer for any specific provider.
+
+## Breaking Change
+
+`1.0.0` should remove runtime support for all plugin-level global discovery configuration.
+
+The following plugin-level fields should no longer affect discovery behavior:
+
+- `discovery.enabled`
+- `providers.include`
+- `providers.exclude`
+- `models.includeRegex`
+- `models.excludeRegex`
+- `smartModelName`
+
+Users must configure discovery behavior under each provider instead:
+
+```json
+{
+  "provider": {
+    "example": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Example",
+      "options": {
+        "baseURL": "https://api.example.com/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "models": {
+            "includeRegex": ["^chat-"],
+            "excludeRegex": ["embedding"]
+          },
+          "smartModelName": true
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Behavior To Preserve
+
+These features should continue working after removing global config support:
+
+- discovery through OpenAI-compatible model list endpoints
+- provider-level `modelsDiscovery.enabled`
+- provider-level `modelsDiscovery.endpoint`
+- provider-level `modelsDiscovery.filterNonChat`
+- provider-level `modelsDiscovery.modelInfoEndpoint`
+- provider-level `modelsDiscovery.modelInfoFormat`
+- provider-level `modelsDiscovery.smartModelName`
+- provider-level `modelsDiscovery.models.includeRegex`
+- provider-level `modelsDiscovery.models.excludeRegex`
+- `/models-discovery:config`
+- `/models-discovery:migrate` when legacy global config is detected
+- legacy global config detection and user-facing warning
+
+## Legacy Detection And Toast
+
+Even though `1.0.0` should stop applying plugin-level global configuration, the plugin should keep detecting it.
+
+When legacy global configuration is present, the plugin should:
+
+- log a warning
+- show a toast warning once per plugin instance after a ready-like event
+- inject `/models-discovery:migrate`
+- not apply the legacy fields to discovery behavior
+
+The `0.12.x` toast says the global config will be deprecated in `v1.0.0`. That message should change in `1.0.0` because the removal has happened.
+
+Suggested `1.0.0` toast message:
+
+```text
+Global opencode-models-discovery config is no longer applied in v1.0.0. Move settings to provider.<name>.options.modelsDiscovery or run /models-discovery:migrate.
+```
+
+Suggested log message:
+
+```text
+Legacy global opencode-models-discovery config was detected but is ignored in v1.0.0. Use provider.<name>.options.modelsDiscovery instead.
+```
+
+The existing ready-event and finite retry behavior should be retained unless the OpenCode plugin runtime provides a more reliable UI-ready event.
+
+## Default Enablement
+
+Discovery should remain enabled by default for providers unless explicitly disabled.
+
+Recommended precedence:
+
+1. `provider.<id>.options.modelsDiscovery.enabled` when explicitly set.
+2. `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED` when set.
+3. Plugin built-in default: `true`.
+
+The environment variable should only control the default for providers without explicit provider-level `modelsDiscovery.enabled`. It must not override an explicit provider-level `true` or `false`.
+
+Suggested false values:
+
+- `false`
+- `0`
+- `no`
+- `off`
+
+Suggested true values:
+
+- `true`
+- `1`
+- `yes`
+- `on`
+
+Invalid values should warn and fall back to the built-in default `true`.
+
+## Provider-Level Dynamic Model Filters
+
+Add provider-level `models.includeBy` and `models.excludeBy` filters under `modelsDiscovery`.
+
+These filters are intended for provider or gateway responses that include extra top-level fields in `/v1/models` items. For example, some gateways may include an `available` field even though `available` is not part of the common OpenAI-compatible `/v1/models` contract.
+
+Example:
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "excludeBy": [
+        {
+          "field": "available",
+          "equals": false
+        }
+      ]
+    }
+  }
+}
+```
+
+This keeps the plugin generic. The plugin should not treat `available` as a built-in standard field, but users can opt into filtering by it when their provider returns it.
+
+### Implemented Filter Shape
+
+Implemented rule shape:
+
+```ts
+type ModelFieldEqualsFilter = {
+  field: string
+  equals: string | number | boolean | null
+}
+
+type ModelFieldMatchFilter = {
+  field: string
+  match: string
+}
+
+type ModelFieldFilter = ModelFieldEqualsFilter | ModelFieldMatchFilter
+```
+
+Provider-level config shape:
+
+```ts
+type ProviderDiscoveryModelsConfig = {
+  includeRegex?: string[]
+  excludeRegex?: string[]
+  includeBy?: ModelFieldFilter[]
+  excludeBy?: ModelFieldFilter[]
+}
+```
+
+### Matching Rules
+
+The implemented matching behavior is intentionally narrow:
+
+- `equals` performs strict equality
+- `match` compiles a JavaScript `RegExp` from a string and matches only string field values
+- each rule must provide exactly one of `equals` or `match`
+- only top-level fields on the raw provider model object are supported
+- missing fields do not match a rule
+- nested paths are not supported
+- coercion is not performed
+- arrays and objects are not accepted as `equals` values
+- invalid `match` regular expressions are ignored with a warning instead of failing config validation
+
+This avoids creating a generic query language before there is a concrete need.
+
+### Filter Order
+
+Implemented filter order:
+
+1. Start with raw discovered models.
+2. Apply `includeBy` if configured.
+3. Apply `excludeBy` if configured.
+4. Apply legacy id regex shortcut behavior.
+5. Apply `filterNonChat` if configured.
+6. Continue with model id normalization and metadata enrichment.
+
+`includeBy` and `excludeBy` are cumulative. `excludeBy` wins over `includeBy` when both match the same model.
+
+Provider-level `models.includeRegex` and `models.excludeRegex` are preserved as id-only shortcuts. Their legacy behavior is unchanged: if `includeRegex` is configured, `excludeRegex` is not applied. `excludeRegex` is applied only when `includeRegex` is absent. New documentation and prompts recommend `includeBy` / `excludeBy` with `field: "id"` and `match` when users need composable id allow-list and deny-list behavior.
+
+### Include And Exclude Semantics
+
+`includeBy` should be inclusive:
+
+- if `includeBy` is empty or missing, it does not filter models
+- if `includeBy` is present, a model must match at least one `includeBy` rule
+
+`excludeBy` should be exclusive:
+
+- if `excludeBy` is empty or missing, it does not filter models
+- if a model matches any `excludeBy` rule, it is removed
+
+If both `includeBy` and `excludeBy` match the same model, exclusion should win.
+
+### Example Use Cases
+
+Exclude unavailable models returned by a gateway:
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "excludeBy": [
+        { "field": "available", "equals": false }
+      ]
+    }
+  }
+}
+```
+
+Include only models marked as usable by a provider-specific field:
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "includeBy": [
+        { "field": "type", "equals": "chat" }
+      ]
+    }
+  }
+}
+```
+
+Combine provider-field filters with id regex filters using the recommended field-filter syntax:
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "excludeBy": [
+        { "field": "available", "equals": false },
+        { "field": "id", "match": "embedding" }
+      ],
+      "includeBy": [
+        { "field": "id", "match": "^deepseek" }
+      ]
+    }
+  }
+}
+```
+
+## `/models-discovery:config` Prompt Update
+
+Update the `/models-discovery:config` command template so it explicitly explains the recommended provider-level model filtering style.
+
+The prompt should state:
+
+- Prefer `includeBy` and `excludeBy` for model filtering.
+- Use `includeBy` / `excludeBy` with `equals` for strict equality against top-level raw provider fields.
+- Use `includeBy` / `excludeBy` with `match` for regular expression matching against string top-level raw provider fields.
+- Use `field: "id"` with `match` for recommended id/name regex filtering.
+- `models.includeRegex` and `models.excludeRegex` remain supported as provider-level id-only shortcuts.
+- `includeRegex` preserves legacy behavior: when it is configured, `excludeRegex` is not applied.
+- Missing fields do not match `includeBy` or `excludeBy` rules.
+
+The migration command should recommend moving legacy global `models.includeRegex` and `models.excludeRegex` to provider-level `modelsDiscovery.models.includeBy` and `modelsDiscovery.models.excludeBy` using `field: "id"` and `match`. It may also mention that provider-level `includeRegex` and `excludeRegex` remain available as id-only shortcuts.
+
+## Documentation Updates
+
+Update user-facing documentation for `1.0.0`:
+
+- `README.md`
+- `docs/configuration.md`
+- `docs/upgrading.md`
+- provider examples where relevant
+
+Required docs changes:
+
+- clearly state that plugin-level global config is ignored in `1.0.0`
+- show provider-level `modelsDiscovery` as the only supported configuration boundary
+- document `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED`
+- document `models.includeBy` and `models.excludeBy` as the recommended provider-level raw-field filters
+- document `equals` and `match` filter modes
+- document `models.includeRegex` and `models.excludeRegex` as provider-level id-only shortcuts with legacy precedence
+- explain that provider-specific fields are not part of the generic OpenAI-compatible contract
+- keep migration guidance for users upgrading from `0.12.x`
+- update the toast/migration command descriptions
+- warn when `modelsDiscovery.includeBy` or `modelsDiscovery.excludeBy` are mistakenly configured outside `modelsDiscovery.models`
+
+## `config_example` Directory
+
+Add a documentation directory for community provider configuration examples:
+
+```text
+docs/config_example/
+```
+
+Initial contents:
+
+- `docs/config_example/README.md`
+- `docs/config_example/deepseek.md`
+
+The main configuration docs should reference this directory for provider-specific examples.
+
+### Directory Purpose
+
+The directory lets users submit practical examples for their own providers without turning the core README into a provider catalog.
+
+Examples may include:
+
+- provider declaration
+- `modelsDiscovery.endpoint` when the provider does not use the standard `/v1/models` path
+- `models.includeRegex` and `models.excludeRegex` filters
+- `models.includeBy` and `models.excludeBy` filters for provider-specific raw fields
+- metadata enrichment options when applicable
+- notes about provider-specific behavior
+
+### Required Disclaimer
+
+`docs/config_example/README.md` should clearly state:
+
+- this project is not affiliated with, endorsed by, or sponsored by the listed providers
+- examples are community-maintained and may become outdated
+- users are responsible for verifying provider legality, terms of service, pricing, data handling, and regional availability
+- examples are not security, legal, compliance, or purchasing advice
+- users should not paste secrets into public issues or pull requests
+- provider credentials should be configured with OpenCode `/connect` when possible or through local private config
+
+### Initial DeepSeek Example
+
+Add `docs/config_example/deepseek.md` as the first example.
+
+The example should prefer the standard OpenAI-compatible provider shape and provider-level discovery options. It should avoid claiming affiliation or endorsement.
+
+Suggested structure:
+
+````md
+# DeepSeek Configuration Example
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by DeepSeek.
+
+## Example
+
+```json
+{
+  "provider": {
+    "deepseek": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "DeepSeek",
+      "options": {
+        "baseURL": "https://api.deepseek.com/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "models": {
+            "includeRegex": ["^deepseek-"]
+          }
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Notes
+
+- Configure credentials with OpenCode `/connect` when possible.
+- Verify the provider's current API base URL and terms before use.
+````
+
+## Implementation Steps
+
+1. Remove runtime application of plugin-level global discovery configuration.
+2. Keep legacy global config detection.
+3. Update the toast and log messages for `1.0.0` removal semantics.
+4. Keep `/models-discovery:migrate` injection when legacy global config is detected.
+5. Add provider-level `models.includeBy` and `models.excludeBy` schema support.
+6. Implement strict top-level equality and string regex matching against raw provider model objects.
+7. Preserve provider-level `models.includeRegex` and `models.excludeRegex` behavior.
+8. Update `/models-discovery:config` and `/models-discovery:migrate` prompt templates.
+9. Update README and usage docs.
+10. Add `docs/config_example/README.md` and `docs/config_example/deepseek.md`.
+11. Add or update tests for removal behavior, warnings, command prompts, and dynamic filters.
+12. Add config warnings for misplaced `modelsDiscovery.includeBy` and `modelsDiscovery.excludeBy`.
+
+## Test Plan
+
+Add tests for:
+
+- legacy global config is detected in `1.0.0`
+- legacy global config no longer changes discovery behavior
+- legacy toast/log message uses `is no longer applied` or equivalent wording
+- `/models-discovery:migrate` is still injected when legacy global config is present
+- provider-level `modelsDiscovery.enabled` still controls discovery
+- default discovery remains enabled when no provider-level config is present
+- `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false` disables default discovery only for unspecified providers
+- explicit provider-level `enabled: true` overrides the env default
+- explicit provider-level `enabled: false` overrides the env default
+- `includeBy` keeps models matching at least one strict equality rule
+- `includeBy` removes models with missing fields
+- `excludeBy` removes models matching any strict equality rule
+- `excludeBy` keeps models with missing fields
+- exclusion wins when both include and exclude rules match
+- `includeBy` supports regex matching with `match`
+- `excludeBy` supports regex matching with `match`
+- nested fields are not treated as paths
+- invalid `equals` values are rejected by validation
+- invalid `match` value types are rejected by validation
+- invalid `match` regular expressions warn and are ignored
+- misplaced `modelsDiscovery.includeBy` and `modelsDiscovery.excludeBy` warn
+- existing `includeRegex` and `excludeRegex` behavior is unchanged
+- command prompts mention `models.includeRegex`, `models.excludeRegex`, `includeBy`, and `excludeBy`
+
+Manual validation completed during implementation:
+
+- `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED` precedence and accepted values were tested in a real OpenCode config.
+- Invalid `match` regex behavior was tested manually: invalid rules warn and are ignored while valid sibling rules still apply.
+- Empty `includeBy` / `excludeBy` arrays were tested manually and do not filter models.
+
+Deferred manual checks:
+
+- Fully combined four-filter interaction beyond preserving existing `includeRegex` / `excludeRegex` behavior.
+- `match` against non-string raw fields.
+- `equals: null` matching.
+
+## Compatibility Notes
+
+The release should be explicit that `1.0.0` is the breaking change promised by `0.12.0`.
+
+Users with only provider-level configuration should not need changes.
+
+Users with plugin-level global configuration need to migrate to provider-level `modelsDiscovery` settings. The plugin should continue to help them discover the problem through warnings and `/models-discovery:migrate`, but it should not keep applying the removed global settings at runtime.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,10 +1,10 @@
 # Upgrading
 
-## v0.12 Transition Release
+## v1.0 Provider-Level Boundary
 
-Version `0.12.x` is a compatibility transition for the provider-level configuration model.
+Version `1.0.0` completes the provider-level configuration migration started in `0.12.0`.
 
-Existing plugin-level discovery config continues to work in `0.12.x`, but it is deprecated:
+Plugin-level discovery config is no longer applied at runtime:
 
 - `discovery.enabled`
 - `providers.include`
@@ -13,22 +13,23 @@ Existing plugin-level discovery config continues to work in `0.12.x`, but it is 
 - `models.excludeRegex`
 - `smartModelName`
 
-When deprecated config is detected, the plugin logs a warning, shows a migration toast, and injects `/models-discovery:migrate` into OpenCode's command list.
+When legacy config is detected, the plugin logs a warning, shows a migration toast, and injects `/models-discovery:migrate` into OpenCode's command list. The legacy fields are ignored for discovery behavior.
 
-For new or updated configs, prefer `provider.<name>.options.modelsDiscovery`.
+Move settings to `provider.<name>.options.modelsDiscovery`.
 
-## v1.0 Compatibility Boundary
+## Discovery Defaults
 
-The planned `1.0.0` compatibility boundary is provider-level discovery config.
+Discovery remains enabled by default for compatible providers.
 
-Expected `1.0.0` behavior:
+Default precedence is:
 
-- Plugin-level discovery config is removed.
-- Discovery remains enabled by default for compatible providers.
-- `provider.<name>.options.modelsDiscovery.enabled = false` disables discovery for one provider.
-- `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false` is planned for users who want providers without explicit config to default to disabled.
+1. `provider.<name>.options.modelsDiscovery.enabled` when explicitly set.
+2. `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED` when set to `true`, `1`, `yes`, `on`, `false`, `0`, `no`, or `off`.
+3. Built-in default `true`.
 
-Use `/models-discovery:config` to get assistant-guided provider-level configuration help. Use `/models-discovery:migrate` to migrate deprecated plugin-level config when it is detected.
+Use `/models-discovery:config` to get assistant-guided provider-level configuration help. Use `/models-discovery:migrate` to migrate legacy plugin-level config when it is detected.
+
+Legacy global `models.includeRegex` and `models.excludeRegex` can map to provider-level `modelsDiscovery.models.includeRegex` and `modelsDiscovery.models.excludeRegex`, but the recommended migration is provider-level `models.includeBy` and `models.excludeBy` using `field: "id"` and `match`. Provider-level `models.includeRegex` and `models.excludeRegex` remain available as id-only shortcuts. Provider-level `models.includeBy` and `models.excludeBy` support strict equality with `equals` and regex matching with `match` against top-level raw fields returned by a provider's `/v1/models` response.
 
 ## Refresh Plugin Cache After Upgrade
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.12.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.12.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "xdg-basedir": "^5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-models-discovery",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-models-discovery",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "xdg-basedir": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-models-discovery",
-  "version": "0.12.0",
+  "version": "1.0.0",
   "description": "OpenCode plugin for auto-discovery of OpenAI-compatible models with dynamic provider configuration",
   "type": "module",
   "main": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-models-discovery",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "OpenCode plugin for auto-discovery of OpenAI-compatible models with dynamic provider configuration",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/plugin/commands.ts
+++ b/src/plugin/commands.ts
@@ -29,10 +29,12 @@ Move these settings into provider.<id>.options.modelsDiscovery where possible.
 
 Field mapping:
 - discovery.enabled -> provider.<id>.options.modelsDiscovery.enabled only when needed to preserve behavior
-- models.includeRegex -> provider.<id>.options.modelsDiscovery.models.includeRegex
-- models.excludeRegex -> provider.<id>.options.modelsDiscovery.models.excludeRegex
+- models.includeRegex -> preferably provider.<id>.options.modelsDiscovery.models.includeBy with { "field": "id", "match": "..." }
+- models.excludeRegex -> preferably provider.<id>.options.modelsDiscovery.models.excludeBy with { "field": "id", "match": "..." }
 - smartModelName -> provider.<id>.options.modelsDiscovery.smartModelName
 - providers.exclude -> provider.<id>.options.modelsDiscovery.enabled=false for excluded editable providers
+
+Provider-level models.includeRegex and models.excludeRegex remain supported as id-only shortcuts, but prefer includeBy and excludeBy for migrated config because they support both id filters and provider-specific raw fields.
 
 Preserve unrelated config fields and formatting as much as possible.
 Do not modify files that do not declare this plugin.
@@ -48,10 +50,10 @@ Explain the mechanism to the user before or after editing:
 - After v1.0.0, provider-level modelsDiscovery is the configuration boundary for this plugin.
 
 For v1.0.0 behavior:
-- plugin-level global discovery config is deprecated
+- plugin-level global discovery config is no longer applied
 - discovery remains enabled by default
 - provider.<id>.options.modelsDiscovery.enabled=false disables discovery for that provider
-- OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false can be used later to make unspecified providers default to disabled
+- OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false can be used to make unspecified providers default to disabled
 
 If providers.include is used, preserve the old opt-in behavior by either recommending OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false with explicit enabled providers, or disabling known non-included editable providers with modelsDiscovery.enabled=false. Prefer explaining the environment variable approach instead of writing many disable entries unless the user asks for a pure config-only migration.
 
@@ -81,8 +83,8 @@ Use provider-level configuration under provider.<id>.options.modelsDiscovery. Pr
           "enabled": true,
           "endpoint": "/v1/models",
           "models": {
-            "includeRegex": "...",
-            "excludeRegex": "..."
+            "includeBy": [{ "field": "id", "match": "^chat-" }],
+            "excludeBy": [{ "field": "available", "equals": false }]
           },
           "smartModelName": true,
           "modelInfoEndpoint": "/v1/model/info",
@@ -107,7 +109,10 @@ Explain the mechanism to the user:
 Supported plugin options under provider.<id>.options.modelsDiscovery:
 - enabled: force enable or disable discovery for this provider
 - endpoint: provider-specific models endpoint path; defaults to /v1/models
-- models.includeRegex and models.excludeRegex: provider-specific model filters
+- models.includeRegex: shortcut for model id regex allow-list; prefer models.includeBy with field="id" and match for new config
+- models.excludeRegex: shortcut for model id regex deny-list; prefer models.excludeBy with field="id" and match for new config
+- models.includeBy: allow-list for top-level raw fields returned in the provider's /v1/models response; each rule uses exactly one of equals or match
+- models.excludeBy: deny-list for top-level raw fields returned in the provider's /v1/models response; each rule uses exactly one of equals or match
 - smartModelName: use friendlier display names for discovered models
 - modelInfoFormat="models.dev": enrich from the public models.dev index without modelInfoEndpoint
 - modelInfoEndpoint plus modelInfoFormat="litellm": enrich from a LiteLLM-compatible model info endpoint
@@ -117,7 +122,16 @@ Recommended defaults:
 - omit modelsDiscovery.enabled when the user is fine with discovery defaulting on
 - set modelsDiscovery.enabled=false to disable discovery for a specific provider
 - omit endpoint when the provider uses the standard /v1/models endpoint
-- use models.includeRegex or models.excludeRegex only when the user wants model filtering
+- prefer models.includeBy and models.excludeBy for model filtering
+- use models.includeBy or models.excludeBy with field="id" and match for id/name regex filtering
+- use models.includeBy or models.excludeBy with equals for strict equality on provider-specific top-level raw model fields
+- use models.includeBy or models.excludeBy with match for regex matching on string top-level raw model fields
+- treat models.includeRegex and models.excludeRegex as id-only shortcuts for includeBy/excludeBy; do not recommend them for new config unless the user asks for the shorter id-only syntax
+- missing fields do not match includeBy or excludeBy rules
+- includeBy and excludeBy are cumulative: a model must pass includeBy first, then excludeBy
+- excludeBy wins over includeBy when both match the same model
+- includeRegex and excludeRegex preserve legacy shortcut behavior: includeRegex takes precedence, so excludeRegex is only applied when includeRegex is not configured
+- avoid configuring both includeBy field="id" match rules and includeRegex unless the user wants an intersection with legacy id-only shortcut behavior
 - use smartModelName=true only when the user wants friendlier display names
 - use modelInfoFormat="models.dev" for models.dev metadata enrichment
 - use modelInfoEndpoint and modelInfoFormat="litellm" for LiteLLM-compatible model info endpoints
@@ -129,11 +143,9 @@ Provider compatibility guidance:
 - modelsDiscovery.enabled=true can force discovery for a provider that does not match automatic compatibility detection.
 
 Configuration compatibility boundary:
-- v0.12.x still supports deprecated plugin-level discovery config for compatibility.
-- v1.0.0 will remove plugin-level discovery config.
+- v1.0.0 ignores plugin-level global discovery config at runtime.
 - Recommended new config should use provider.<id>.options.modelsDiscovery.
-- Discovery is planned to remain enabled by default in v1.0.0 unless a provider sets modelsDiscovery.enabled=false.
-- A future OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false environment variable is planned for users who want unspecified providers to default to disabled.
+- Discovery remains enabled by default unless a provider sets modelsDiscovery.enabled=false or OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false is set for unspecified providers.
 
 Preserve unrelated config fields and formatting as much as possible.
 Do not overwrite existing provider.<id>.options.modelsDiscovery fields unless the user explicitly asks you to.

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -5,7 +5,7 @@ import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
-import { getProviderFilter, getDiscoveryConfig, getModelRegexFilter, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
+import { getDefaultDiscoveryConfigFromEnv, getProviderModelFieldFilters, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverModelByFields, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
 import { fetchModelsDevData } from '../utils/models-dev-fetcher'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
@@ -175,10 +175,8 @@ export async function enhanceConfig(
   try {
     const providers = config.provider || {}
     const openAICompatibleProviders: DiscoveredProvider[] = []
-    const providerFilter = getProviderFilter(pluginConfig)
-    const modelRegexFilter = getModelRegexFilter(pluginConfig, logger.child({ category: 'filtering' }))
-    const discoveryConfig = getDiscoveryConfig(pluginConfig)
-    const globalDiscoveryEnabled = discoveryConfig.enabled
+    const discoveryConfig = getDefaultDiscoveryConfigFromEnv(logger.child({ category: 'config' }))
+    const defaultDiscoveryEnabled = discoveryConfig.enabled
     const resolvedProvidersLoader: ResolvedProvidersLoader = {}
 
     for (const [providerName, providerConfig] of Object.entries(providers)) {
@@ -194,7 +192,7 @@ export async function enhanceConfig(
         continue
       }
 
-      if (!shouldDiscoverProviderWithOverride(providerName, providerFilter, globalDiscoveryEnabled, providerDiscoveryConfig)) {
+      if (!shouldDiscoverProviderWithOverride(defaultDiscoveryEnabled, providerDiscoveryConfig)) {
         logger.debug(`Provider ${providerName} model discovery disabled by configuration`)
         continue
       }
@@ -260,25 +258,26 @@ export async function enhanceConfig(
 
       const hasProviderModelRegexFilter = !!providerDiscoveryConfig.models?.includeRegex?.length || !!providerDiscoveryConfig.models?.excludeRegex?.length
       const providerModelRegexFilter = getProviderModelRegexFilter(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
-      let smartModelNameEnabled = providerDiscoveryConfig.smartModelName
-      if (smartModelNameEnabled === undefined) {
-        smartModelNameEnabled = pluginConfig.smartModelName
-      }
+      const providerModelFieldFilters = getProviderModelFieldFilters(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
+      const smartModelNameEnabled = providerDiscoveryConfig.smartModelName === true
 
       for (const model of models) {
         const modelKey = model.id
         if (!existingModels[modelKey]) {
-          const activeModelRegexFilter = hasProviderModelRegexFilter ? providerModelRegexFilter : modelRegexFilter
-          if (!shouldDiscoverModel(model.id, activeModelRegexFilter)) {
+          if (!shouldDiscoverModelByFields(model, providerModelFieldFilters)) {
             continue
           }
 
-          if (modelInfoEnricher?.shouldSkipModel(model.id)) {
+          if (hasProviderModelRegexFilter && !shouldDiscoverModel(model.id, providerModelRegexFilter)) {
             continue
           }
 
           const modelType = categorizeModel(model.id)
           if (modelType === 'embedding') {
+            continue
+          }
+
+          if (modelInfoEnricher?.shouldSkipModel(model.id)) {
             continue
           }
 

--- a/src/plugin/legacy-config-warning.ts
+++ b/src/plugin/legacy-config-warning.ts
@@ -1,7 +1,7 @@
 import { ToastNotifier } from '../ui/toast-notifier'
 import type { PluginLogger } from './logger'
 
-const LEGACY_GLOBAL_CONFIG_WARNING = 'Global opencode-models-discovery config will be deprecated in v1.0.0. Use provider.<name>.options.modelsDiscovery instead. Run /models-discovery:migrate to migrate config.'
+const LEGACY_GLOBAL_CONFIG_WARNING = 'Global opencode-models-discovery config is no longer applied in v1.0.0. Move settings to provider.<name>.options.modelsDiscovery or run /models-discovery:migrate.'
 const TOAST_RETRY_DELAYS_MS = [500, 1500, 3000, 5000]
 
 const TOAST_READY_EVENTS = new Set([
@@ -35,9 +35,9 @@ export function createLegacyGlobalConfigWarningController(): LegacyGlobalConfigW
 
       if (!logged) {
         logged = true
-        logger.warn('Legacy global discovery configuration is deprecated', {
+        logger.warn('Legacy global opencode-models-discovery config was detected but is ignored in v1.0.0. Use provider.<name>.options.modelsDiscovery instead.', {
           migrationCommand: '/models-discovery:migrate',
-          deprecatedIn: 'v1.0.0',
+          ignoredSince: 'v1.0.0',
         })
       }
     },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface OpenAIModel {
   object: string
   created: number
   owned_by: string
+  [key: string]: unknown
 }
 
 export interface OpenAIModelsResponse {

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -13,6 +13,22 @@ export interface PluginConfig {
   smartModelName?: boolean
 }
 
+export type ModelFieldFilterValue = string | number | boolean | null
+
+export interface ModelFieldEqualsFilter {
+  field: string
+  equals: ModelFieldFilterValue
+}
+
+export interface ModelFieldMatchFilter {
+  field: string
+  match: string
+}
+
+export type ModelFieldFilter = ModelFieldEqualsFilter | ModelFieldMatchFilter
+
+export type CompiledModelFieldFilter = ModelFieldEqualsFilter | (Omit<ModelFieldMatchFilter, 'match'> & { match: RegExp })
+
 export type ModelInfoFormat = 'litellm' | 'models.dev' | (string & {})
 
 export interface ProviderDiscoveryConfig {
@@ -24,13 +40,10 @@ export interface ProviderDiscoveryConfig {
   models?: {
     includeRegex?: string[]
     excludeRegex?: string[]
+    includeBy?: ModelFieldFilter[]
+    excludeBy?: ModelFieldFilter[]
   }
   smartModelName?: boolean
-}
-
-export interface ProviderFilter {
-  include: string[]
-  exclude: string[]
 }
 
 export interface DiscoveryConfig {
@@ -42,31 +55,41 @@ export interface ModelRegexFilter {
   excludeRegex: RegExp[]
 }
 
+export interface ModelFieldFilters {
+  includeBy: CompiledModelFieldFilter[]
+  excludeBy: CompiledModelFieldFilter[]
+}
+
 export const DEFAULT_DISCOVERY_CONFIG: DiscoveryConfig = {
   enabled: true,
 }
 
-export function shouldDiscoverProvider(
-  providerName: string,
-  filter: ProviderFilter
-): boolean {
-  if (filter.include.length > 0) {
-    return filter.include.includes(providerName)
-  }
-  return !filter.exclude.includes(providerName)
-}
+export function getDefaultDiscoveryConfigFromEnv(logger?: PluginLogger): DiscoveryConfig {
+  const rawValue = process.env.OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED
 
-export function getProviderFilter(config: PluginConfig): ProviderFilter {
-  return {
-    include: config.providers?.include || [],
-    exclude: config.providers?.exclude || [],
+  if (rawValue === undefined) {
+    return DEFAULT_DISCOVERY_CONFIG
   }
-}
 
-export function getDiscoveryConfig(config: PluginConfig): DiscoveryConfig {
-  return {
-    enabled: config.discovery?.enabled ?? DEFAULT_DISCOVERY_CONFIG.enabled,
+  const normalizedValue = rawValue.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(normalizedValue)) {
+    return { enabled: true }
   }
+
+  if (['false', '0', 'no', 'off'].includes(normalizedValue)) {
+    return { enabled: false }
+  }
+
+  if (logger) {
+    logger.warn('Ignoring invalid OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED value', {
+      value: rawValue,
+      fallback: DEFAULT_DISCOVERY_CONFIG.enabled,
+    })
+  } else {
+    console.warn(`[opencode-models-discovery] Ignoring invalid OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED value: ${rawValue}`)
+  }
+
+  return DEFAULT_DISCOVERY_CONFIG
 }
 
 export function hasLegacyGlobalDiscoveryConfig(config: PluginConfig): boolean {
@@ -79,9 +102,7 @@ export function hasLegacyGlobalDiscoveryConfig(config: PluginConfig): boolean {
 }
 
 export function shouldDiscoverProviderWithOverride(
-  providerName: string,
-  filter: ProviderFilter,
-  globalEnabled: boolean,
+  defaultEnabled: boolean,
   providerConfig: ProviderDiscoveryConfig
 ): boolean {
   if (providerConfig.enabled === true) {
@@ -92,11 +113,7 @@ export function shouldDiscoverProviderWithOverride(
     return false
   }
 
-  if (!globalEnabled) {
-    return false
-  }
-
-  return shouldDiscoverProvider(providerName, filter)
+  return defaultEnabled
 }
 
 function toRegExp(pattern: string, logger?: PluginLogger): RegExp | null {
@@ -112,18 +129,63 @@ function toRegExp(pattern: string, logger?: PluginLogger): RegExp | null {
   }
 }
 
-export function getModelRegexFilter(config: PluginConfig, logger?: PluginLogger): ModelRegexFilter {
+export function getProviderModelRegexFilter(config: ProviderDiscoveryConfig, logger?: PluginLogger): ModelRegexFilter {
   return {
     includeRegex: (config.models?.includeRegex || []).map((pattern) => toRegExp(pattern, logger)).filter((pattern): pattern is RegExp => pattern !== null),
     excludeRegex: (config.models?.excludeRegex || []).map((pattern) => toRegExp(pattern, logger)).filter((pattern): pattern is RegExp => pattern !== null),
   }
 }
 
-export function getProviderModelRegexFilter(config: ProviderDiscoveryConfig, logger?: PluginLogger): ModelRegexFilter {
-  return {
-    includeRegex: (config.models?.includeRegex || []).map((pattern) => toRegExp(pattern, logger)).filter((pattern): pattern is RegExp => pattern !== null),
-    excludeRegex: (config.models?.excludeRegex || []).map((pattern) => toRegExp(pattern, logger)).filter((pattern): pattern is RegExp => pattern !== null),
+function toModelFieldFilter(filter: ModelFieldFilter, logger?: PluginLogger): CompiledModelFieldFilter | null {
+  if ('match' in filter) {
+    try {
+      return {
+        field: filter.field,
+        match: new RegExp(filter.match),
+      }
+    } catch {
+      if (logger) {
+        logger.warn('Ignoring invalid model field regex', { category: 'filtering', field: filter.field, pattern: filter.match })
+      } else {
+        console.warn(`[opencode-models-discovery] Ignoring invalid model field regex for ${filter.field}: ${filter.match}`)
+      }
+      return null
+    }
   }
+
+  return filter
+}
+
+export function getProviderModelFieldFilters(config: ProviderDiscoveryConfig, logger?: PluginLogger): ModelFieldFilters {
+  return {
+    includeBy: (config.models?.includeBy || []).map((filter) => toModelFieldFilter(filter, logger)).filter((filter): filter is CompiledModelFieldFilter => filter !== null),
+    excludeBy: (config.models?.excludeBy || []).map((filter) => toModelFieldFilter(filter, logger)).filter((filter): filter is CompiledModelFieldFilter => filter !== null),
+  }
+}
+
+function matchesModelFieldFilter(model: Record<string, unknown>, filter: CompiledModelFieldFilter): boolean {
+  if (!Object.prototype.hasOwnProperty.call(model, filter.field)) {
+    return false
+  }
+
+  const value = model[filter.field]
+  if ('match' in filter) {
+    return typeof value === 'string' && filter.match.test(value)
+  }
+
+  return value === filter.equals
+}
+
+export function shouldDiscoverModelByFields(model: Record<string, unknown>, filters: ModelFieldFilters): boolean {
+  if (filters.includeBy.length > 0 && !filters.includeBy.some((filter) => matchesModelFieldFilter(model, filter))) {
+    return false
+  }
+
+  if (filters.excludeBy.some((filter) => matchesModelFieldFilter(model, filter))) {
+    return false
+  }
+
+  return true
 }
 
 export function shouldDiscoverModel(modelId: string, filter: ModelRegexFilter): boolean {

--- a/src/utils/validation/validate-config.ts
+++ b/src/utils/validation/validate-config.ts
@@ -14,6 +14,8 @@ export function validateConfig(config: any): ValidationResult {
     for (const [providerName, providerConfig] of Object.entries(config.provider)) {
       const p = providerConfig as any
       const forceDiscoveryEnabled = p.options?.modelsDiscovery?.enabled === true
+      const discoveryConfig = p.options?.modelsDiscovery
+      const discoveryModels = p.options?.modelsDiscovery?.models
 
       if (forceDiscoveryEnabled || canDiscoverModels(p)) {
         if (!p.options?.baseURL) {
@@ -23,6 +25,15 @@ export function validateConfig(config: any): ValidationResult {
           errors.push(`Provider '${providerName}' models must be an object`)
         }
       }
+
+      if (discoveryModels && typeof discoveryModels === 'object') {
+        validateModelFieldFilters(providerName, 'includeBy', discoveryModels.includeBy, errors)
+        validateModelFieldFilters(providerName, 'excludeBy', discoveryModels.excludeBy, errors)
+      }
+
+      if (discoveryConfig && typeof discoveryConfig === 'object') {
+        warnMisplacedModelFieldFilters(providerName, discoveryConfig, warnings)
+      }
     }
   }
 
@@ -31,4 +42,53 @@ export function validateConfig(config: any): ValidationResult {
     errors,
     warnings
   }
+}
+
+function warnMisplacedModelFieldFilters(providerName: string, discoveryConfig: Record<string, unknown>, warnings: string[]): void {
+  for (const key of ['includeBy', 'excludeBy'] as const) {
+    if (Object.prototype.hasOwnProperty.call(discoveryConfig, key)) {
+      warnings.push(`Provider '${providerName}' modelsDiscovery.${key} is ignored; use modelsDiscovery.models.${key} instead`)
+    }
+  }
+}
+
+function validateModelFieldFilters(providerName: string, key: 'includeBy' | 'excludeBy', value: unknown, errors: string[]): void {
+  if (value === undefined) {
+    return
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push(`Provider '${providerName}' modelsDiscovery.models.${key} must be an array`)
+    return
+  }
+
+  value.forEach((rule, index) => {
+    if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+      errors.push(`Provider '${providerName}' modelsDiscovery.models.${key}[${index}] must be an object`)
+      return
+    }
+
+    const field = (rule as any).field
+    const hasEquals = Object.prototype.hasOwnProperty.call(rule, 'equals')
+    const hasMatch = Object.prototype.hasOwnProperty.call(rule, 'match')
+    const equals = (rule as any).equals
+    const match = (rule as any).match
+
+    if (typeof field !== 'string' || field.length === 0) {
+      errors.push(`Provider '${providerName}' modelsDiscovery.models.${key}[${index}].field must be a non-empty string`)
+    }
+
+    if (hasEquals === hasMatch) {
+      errors.push(`Provider '${providerName}' modelsDiscovery.models.${key}[${index}] must include exactly one of equals or match`)
+      return
+    }
+
+    if (hasEquals && !(equals === null || ['string', 'number', 'boolean'].includes(typeof equals))) {
+      errors.push(`Provider '${providerName}' modelsDiscovery.models.${key}[${index}].equals must be a string, number, boolean, or null`)
+    }
+
+    if (hasMatch && typeof match !== 'string') {
+      errors.push(`Provider '${providerName}' modelsDiscovery.models.${key}[${index}].match must be a string`)
+    }
+  })
 }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -68,6 +68,7 @@ describe('ModelDiscovery Plugin', () => {
     delete process.env.OPENCODE_PID
     delete process.env.MIMOCODE
     delete process.env.MIMOCODE_PID
+    delete process.env.OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED
 
     mockClient = {
       app: {
@@ -105,6 +106,7 @@ describe('ModelDiscovery Plugin', () => {
     delete process.env.OPENCODE_PID
     delete process.env.MIMOCODE
     delete process.env.MIMOCODE_PID
+    delete process.env.OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED
     vi.restoreAllMocks()
   })
 
@@ -250,8 +252,9 @@ describe('ModelDiscovery Plugin', () => {
         expect(config.command['models-discovery:config'].template).toContain('OpenCode /connect credentials')
         expect(config.command['models-discovery:config'].template).toContain('@ai-sdk/openai-compatible')
         expect(config.command['models-discovery:config'].template).toContain('non-standard models paths should set modelsDiscovery.endpoint')
-        expect(config.command['models-discovery:config'].template).toContain('v0.12.x still supports deprecated plugin-level discovery config')
-        expect(config.command['models-discovery:config'].template).toContain('v1.0.0 will remove plugin-level discovery config')
+        expect(config.command['models-discovery:config'].template).toContain('v1.0.0 ignores plugin-level global discovery config at runtime')
+        expect(config.command['models-discovery:config'].template).toContain('includeBy')
+        expect(config.command['models-discovery:config'].template).toContain('excludeBy')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="models.dev"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="litellm"')
         expect(config.command['models-discovery:config'].template).toContain('restart opencode')
@@ -271,7 +274,7 @@ describe('ModelDiscovery Plugin', () => {
           body: expect.objectContaining({
             title: 'Discovery Config Migration',
             variant: 'warning',
-            message: expect.stringContaining('Global opencode-models-discovery config will be deprecated in v1.0.0')
+            message: expect.stringContaining('Global opencode-models-discovery config is no longer applied in v1.0.0')
           })
         })
 
@@ -292,7 +295,7 @@ describe('ModelDiscovery Plugin', () => {
         expect(mockClient.app.log).toHaveBeenCalledWith(expect.objectContaining({
           body: expect.objectContaining({
             level: 'warn',
-            message: 'Legacy global discovery configuration is deprecated',
+            message: 'Legacy global opencode-models-discovery config was detected but is ignored in v1.0.0. Use provider.<name>.options.modelsDiscovery instead.',
             extra: expect.objectContaining({
               category: 'config',
               migrationCommand: '/models-discovery:migrate'
@@ -337,6 +340,53 @@ describe('ModelDiscovery Plugin', () => {
         template: expect.stringContaining('Use the customize-opencode skill.'),
       }))
       expect(config.command['models-discovery:migrate']).toBeUndefined()
+    })
+
+    it('should warn when includeBy or excludeBy are placed outside modelsDiscovery.models', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: []
+        })
+      })
+
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                includeBy: [
+                  { field: 'id', match: '^deepseek-' }
+                ],
+                excludeBy: [
+                  { field: 'id', match: 'embedding' }
+                ]
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockClient.app.log).toHaveBeenCalledWith(expect.objectContaining({
+        body: expect.objectContaining({
+          service: 'opencode-models-discovery',
+          level: 'warn',
+          message: 'Config warnings',
+          extra: expect.objectContaining({
+            category: 'config',
+            warnings: expect.arrayContaining([
+              "Provider 'gateway' modelsDiscovery.includeBy is ignored; use modelsDiscovery.models.includeBy instead",
+              "Provider 'gateway' modelsDiscovery.excludeBy is ignored; use modelsDiscovery.models.excludeBy instead"
+            ])
+          })
+        })
+      }))
     })
 
     it('should not overwrite existing migration and config commands', async () => {
@@ -1124,34 +1174,23 @@ describe('ModelDiscovery Plugin', () => {
         })
       })
 
-      const hooksWithConfig = await ModelDiscoveryPlugin({
-        client: mockClient,
-        project: {
-          id: 'test-project',
-          name: 'test',
-          path: '/tmp',
-          worktree: '',
-          time: { created: Date.now() }
-        },
-        directory: '/tmp',
-        worktree: '',
-        $: vi.fn()
-      }, {
-        smartModelName: true
-      })
-
       const config: any = {
         provider: {
           ollama: {
             npm: '@ai-sdk/openai-compatible',
             name: 'Ollama',
-            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            options: {
+              baseURL: 'http://127.0.0.1:11434/v1',
+              modelsDiscovery: {
+                smartModelName: true
+              }
+            },
             models: {}
           }
         }
       }
 
-      await hooksWithConfig.config(config)
+      await pluginHooks.config(config)
 
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toEqual(
         expect.objectContaining({
@@ -1233,7 +1272,7 @@ describe('ModelDiscovery Plugin', () => {
       }))
     })
 
-    it('should skip providers in exclude list', async () => {
+    it('should ignore legacy providers.exclude at runtime', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1276,10 +1315,10 @@ describe('ModelDiscovery Plugin', () => {
 
       await hooksWithConfig.config(config)
 
-      // Filter check happens silently
+      expect(config.provider?.ollama?.models?.['test-model']).toBeDefined()
     })
 
-    it('should only discover providers in include list', async () => {
+    it('should ignore legacy providers.include at runtime', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1329,10 +1368,10 @@ describe('ModelDiscovery Plugin', () => {
       await hooksWithConfig.config(config)
 
       expect(config.provider?.lmstudio?.models?.['test-model']).toBeDefined()
-      expect(config.provider?.ollama?.models).toEqual({})
+      expect(config.provider?.ollama?.models?.['test-model']).toBeDefined()
     })
 
-    it('should skip discovery when discovery.enabled is false', async () => {
+    it('should ignore legacy discovery.enabled=false at runtime', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1375,10 +1414,10 @@ describe('ModelDiscovery Plugin', () => {
 
       await hooksWithConfig.config(config)
 
-      expect(config.provider?.ollama?.models).toEqual({})
+      expect(config.provider?.ollama?.models?.['test-model']).toBeDefined()
     })
 
-    it('should allow provider-level discovery when global discovery is disabled', async () => {
+    it('should allow provider-level discovery when legacy global discovery is disabled', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1514,7 +1553,7 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider?.ollama?.models).toEqual({})
     })
 
-    it('should only discover models matching includeRegex', async () => {
+    it('should ignore legacy global model includeRegex at runtime', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1559,10 +1598,10 @@ describe('ModelDiscovery Plugin', () => {
       await hooksWithConfig.config(config)
 
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toBeDefined()
-      expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
+      expect(config.provider.ollama.models['bge-m3']).toBeDefined()
     })
 
-    it('should skip models matching excludeRegex', async () => {
+    it('should ignore legacy global model excludeRegex at runtime', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1607,7 +1646,7 @@ describe('ModelDiscovery Plugin', () => {
       await hooksWithConfig.config(config)
 
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toBeDefined()
-      expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
+      expect(config.provider.ollama.models['bge-m3']).toBeDefined()
     })
 
     it('should preserve explicitly configured models even when regex would filter them out', async () => {
@@ -1660,7 +1699,7 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.ollama.models['discover-me']).toBeDefined()
     })
 
-    it('should prefer provider-level model filters over global filters', async () => {
+    it('should use provider-level model filters and smart model names', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1721,7 +1760,7 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
     })
 
-    it('should use global model filters when provider-level filters are not configured', async () => {
+    it('should ignore legacy global model filters when provider-level filters are not configured', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1770,7 +1809,257 @@ describe('ModelDiscovery Plugin', () => {
 
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toBeDefined()
       expect(config.provider.ollama.models['qwen/qwen3-8b']).toBeDefined()
-      expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
+      expect(config.provider.ollama.models['bge-m3']).toBeDefined()
+    })
+
+    it('should use OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false only for unspecified providers', async () => {
+      process.env.OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED = 'false'
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'test-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          disabledByDefault: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Disabled By Default',
+            options: { baseURL: 'http://127.0.0.1:11434/v1' },
+            models: {}
+          },
+          explicitlyEnabled: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Explicitly Enabled',
+            options: {
+              baseURL: 'http://127.0.0.1:1234/v1',
+              modelsDiscovery: { enabled: true }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.disabledByDefault.models).toEqual({})
+      expect(config.provider.explicitlyEnabled.models['test-model']).toBeDefined()
+    })
+
+    it('should let explicit provider-level enabled=false override env default true', async () => {
+      process.env.OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED = 'true'
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'test-model', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          ollama: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Ollama',
+            options: {
+              baseURL: 'http://127.0.0.1:11434/v1',
+              modelsDiscovery: { enabled: false }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.ollama.models).toEqual({})
+    })
+
+    it('should filter models by provider-level includeBy and excludeBy raw fields', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'chat-available', object: 'model', created: 1234567890, owned_by: 'local', type: 'chat', available: true },
+            { id: 'chat-unavailable', object: 'model', created: 1234567890, owned_by: 'local', type: 'chat', available: false },
+            { id: 'embedding-available', object: 'model', created: 1234567890, owned_by: 'local', type: 'embedding', available: true },
+            { id: 'missing-fields', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  includeBy: [{ field: 'type', equals: 'chat' }],
+                  excludeBy: [{ field: 'available', equals: false }]
+                }
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.gateway.models['chat-available']).toBeDefined()
+      expect(config.provider.gateway.models['chat-unavailable']).toBeUndefined()
+      expect(config.provider.gateway.models['embedding-available']).toBeUndefined()
+      expect(config.provider.gateway.models['missing-fields']).toBeUndefined()
+    })
+
+    it('should not treat nested field names as paths for includeBy', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'nested-only', object: 'model', created: 1234567890, owned_by: 'local', metadata: { type: 'chat' } },
+            { id: 'literal-field', object: 'model', created: 1234567890, owned_by: 'local', 'metadata.type': 'chat' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  includeBy: [{ field: 'metadata.type', equals: 'chat' }]
+                }
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.gateway.models['nested-only']).toBeUndefined()
+      expect(config.provider.gateway.models['literal-field']).toBeDefined()
+    })
+
+    it('should reject invalid includeBy equals values', async () => {
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  includeBy: [{ field: 'metadata', equals: { type: 'chat' } }]
+                }
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockClient.app.log).toHaveBeenLastCalledWith(expect.objectContaining({
+        body: expect.objectContaining({
+          service: 'opencode-models-discovery',
+          level: 'error',
+          message: 'Invalid config provided',
+          extra: expect.objectContaining({
+            category: 'config',
+            errors: expect.arrayContaining(["Provider 'gateway' modelsDiscovery.models.includeBy[0].equals must be a string, number, boolean, or null"])
+          })
+        })
+      }))
+    })
+
+    it('should filter models by provider-level includeBy and excludeBy regex matches', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'deepseek-chat', object: 'model', created: 1234567890, owned_by: 'local' },
+            { id: 'deepseek-reasoner', object: 'model', created: 1234567890, owned_by: 'local' },
+            { id: 'deepseek-embedding', object: 'model', created: 1234567890, owned_by: 'local' },
+            { id: 'qwen-chat', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  includeBy: [{ field: 'id', match: '^deepseek-' }],
+                  excludeBy: [{ field: 'id', match: 'embedding$' }]
+                }
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.gateway.models['deepseek-chat']).toBeDefined()
+      expect(config.provider.gateway.models['deepseek-reasoner']).toBeDefined()
+      expect(config.provider.gateway.models['deepseek-embedding']).toBeUndefined()
+      expect(config.provider.gateway.models['qwen-chat']).toBeUndefined()
+    })
+
+    it('should reject field filters that specify both equals and match', async () => {
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  excludeBy: [{ field: 'id', equals: 'test', match: '^test' }]
+                }
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockClient.app.log).toHaveBeenLastCalledWith(expect.objectContaining({
+        body: expect.objectContaining({
+          service: 'opencode-models-discovery',
+          level: 'error',
+          message: 'Invalid config provided',
+          extra: expect.objectContaining({
+            category: 'config',
+            errors: expect.arrayContaining(["Provider 'gateway' modelsDiscovery.models.excludeBy[0] must include exactly one of equals or match"])
+          })
+        })
+      }))
     })
   })
 


### PR DESCRIPTION
## Summary

This PR prepares `opencode-models-discovery` for `v1.0.0` by completing the provider-level configuration migration started in `v0.12.0`.

The main breaking change is that plugin-level global discovery config is no longer applied at runtime. Provider-level config under `provider.<id>.options.modelsDiscovery` is now the supported configuration boundary.

## Key Changes

### Provider-Level Configuration Boundary

- Remove runtime application of legacy plugin-level global discovery config:
  - `discovery.enabled`
  - `providers.include`
  - `providers.exclude`
  - `models.includeRegex`
  - `models.excludeRegex`
  - `smartModelName`
- Keep legacy config detection for migration support.
- Keep warning logs, migration toast behavior, and `/models-discovery:migrate` injection when legacy config is detected.
- Update warning copy to reflect `v1.0.0` behavior: legacy global config is ignored, not merely deprecated.

### Discovery Default Enablement

- Add `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED`.
- Supported truthy values:
  - `true`
  - `1`
  - `yes`
  - `on`
- Supported falsy values:
  - `false`
  - `0`
  - `no`
  - `off`
- Invalid values warn and fall back to the built-in default `true`.
- Provider-level `modelsDiscovery.enabled` always takes precedence over the environment default.

### Provider-Level Model Filters

- Add provider-level `models.includeBy` and `models.excludeBy` under `modelsDiscovery.models`.
- Support two rule modes:
  - `equals`: strict equality against `string | number | boolean | null`
  - `match`: JavaScript regular expression string, applied only to string field values
- Rules only match top-level fields on the raw provider `/v1/models` response object.
- Missing fields do not match.
- Nested paths are not interpreted.
- No type coercion is performed.
- Invalid `match` regex strings are ignored with a warning.

Recommended new filtering style:

```json
{
  "modelsDiscovery": {
    "models": {
      "includeBy": [
        { "field": "id", "match": "^deepseek" }
      ],
      "excludeBy": [
        { "field": "available", "equals": false },
        { "field": "id", "match": "embedding" }
      ]
    }
  }
}
```

### Regex Shortcut Compatibility
- Preserve provider-level models.includeRegex and models.excludeRegex.
- Document them as legacy id-only shortcuts.
- Preserve existing shortcut behavior:
   - includeRegex is applied first when configured.
   - excludeRegex is only applied when includeRegex is not configured.
- Recommend includeBy / excludeBy with field: "id" and match for new configs that need composable id allow-list and deny-list behavior.
 
### Config Validation
- Add validation for includeBy / excludeBy rule shape.
- Reject invalid equals values such as arrays or objects.
- Reject rules that specify both equals and match.
- Reject non-string match values.
- Warn when users mistakenly configure:
   - modelsDiscovery.includeBy
   - modelsDiscovery.excludeBy

The correct location is:
```json 
{
  "modelsDiscovery": {
    "models": {
      "includeBy": [],
      "excludeBy": []
    }
  }
}
```

### Helper Commands
- Update /models-discovery:config prompt:
   - Recommends provider-level modelsDiscovery.
   - Recommends includeBy / excludeBy.
   - Explains equals and match.
   - Explains includeRegex / excludeRegex as id-only shortcuts.
   - Explains legacy global config is ignored in v1.0.0.
- Update /models-discovery:migrate prompt:
   - Recommends migrating legacy global model regex filters to provider-level includeBy / excludeBy using field: "id" and match.
   - Keeps provider-level includeRegex / excludeRegex as supported id-only shortcut alternatives.
### Documentation
- Update:
   - README.md
   - docs/configuration.md
   - docs/upgrading.md
- Add community config examples:
   - docs/config_example/README.md
   - docs/config_example/deepseek.md
- Add v1.0.0 PRD:
   - docs/issues/v1.0.0-provider-level-config-prd.md
   - Add docs/articles/ to .gitignore.

## Breaking Change
Plugin-level global discovery config is now ignored at runtime.
Users should migrate from this style:  
```json
{
  "plugin": [
    [
      "opencode-models-discovery",
      {
        "discovery": {
          "enabled": false
        },
        "models": {
          "includeRegex": ["^deepseek"]
        },
        "smartModelName": true
      }
    ]
  ]
}
```

To provider-level config:
```json
{
  "provider": {
    "example": {
      "options": {
        "modelsDiscovery": {
          "enabled": false,
          "smartModelName": true,
          "models": {
            "includeBy": [
              { "field": "id", "match": "^deepseek" }
            ]
          }
        }
      }
    }
  }
}
```

Legacy global config is still detected. When present, the plugin logs a warning, shows a migration toast, and injects /models-discovery:migrate.