### PR TITLE
Fix models.dev matching for custom provider models

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ This keeps the same provider configuration model while allowing the plugin to wo
 - Provider compatibility and detection rules: [`docs/providers.md`](docs/providers.md)
 - Upgrade notes: [`docs/upgrading.md`](docs/upgrading.md)
 
+Provider users are welcome to contribute community-maintained configuration examples under [`docs/config_example/`](docs/config_example/). Please target the `community/config-examples` branch and keep example PRs scoped to a new example file plus its README link.
+
 ## Requirements
 
 - OpenCode with plugin support

--- a/docs/config_example/README.md
+++ b/docs/config_example/README.md
@@ -17,3 +17,24 @@ Do not paste secrets into public issues or pull requests. Configure provider cre
 ## Examples
 
 - [DeepSeek](deepseek.md)
+
+## Community Example PR Scope
+
+Community provider example PRs are welcome, but they must stay narrowly scoped. Submit these PRs against the `community/config-examples` branch unless maintainers request another target.
+
+Acceptable changes for a provider example PR:
+
+- Add a new Markdown file under `docs/config_example/`.
+- Add one link to that new file in this README's examples list.
+
+Do not include unrelated changes in provider example PRs. In particular, do not modify runtime source code, package metadata, release files, workflows, tests, or general documentation outside `docs/config_example/`.
+
+Each example should:
+
+- Use provider-level `provider.<id>.options.modelsDiscovery` config.
+- Prefer `models.includeBy` and `models.excludeBy` over `includeRegex` and `excludeRegex`.
+- Avoid secrets, tokens, API keys, account IDs, or private URLs.
+- Include a provider-specific disclaimer that this project is not affiliated with, endorsed by, or sponsored by that provider.
+- Ask users to verify current API endpoints, pricing, terms of service, data handling, and regional availability.
+
+Maintainers may close or request changes on PRs that exceed this scope, add promotional language, include secrets, or present provider examples as official endorsements.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,9 +229,8 @@ When a discovered model can be matched to models.dev metadata, the plugin may po
 Matching is intentionally conservative:
 
 - Exact model ids are preferred.
-- Provider-qualified matches stay within the same provider.
-- Model-only matches are used only when the discovered model id has no provider prefix.
-- Prefix matching is limited to strong same-provider variants, such as date-suffixed model ids.
+- Provider ids are not used for models.dev matching; only the model-name segment is matched.
+- Prefix matching is limited to strong model-name variants, such as date-suffixed model ids.
 
 If models.dev cannot be fetched, or if no safe match is found, discovery still succeeds and the plugin leaves metadata fields unset. It does not inject hardcoded default context or output limits for unknown models.
 

--- a/docs/issues/pr-26-models-dev-metadata.md
+++ b/docs/issues/pr-26-models-dev-metadata.md
@@ -88,20 +88,18 @@ Those fields may be useful later, but they should not be added to generated Open
 
 ## Matching Strategy
 
-The matcher is intentionally conservative.
+The matcher is intentionally based on model names, not provider ids, so custom provider ids can still use models.dev metadata.
 
 Exact id matches are preferred first.
 
-Provider-qualified model ids stay within the same provider. For example, `openai/gpt-4o` may match `openai/gpt-4o`, but `custom/gpt-4o` will not fall back to `openai/gpt-4o` just because the model name is the same.
+Provider-qualified model ids may match models.dev entries from a different provider when the model-name segment is the same. For example, `custom/gpt-4o` may match the models.dev `openai/gpt-4o` entry by model name.
 
-Model-only matches are allowed only when the discovered model id has no provider prefix. For example, `gpt-4o` may match a known `openai/gpt-4o` entry, but `custom/gpt-4o` will not.
-
-Prefix matching is limited to strong variants within the same provider. It requires:
+Prefix matching is limited to strong model-name variants. It requires:
 
 - at least two shared hyphen-delimited prefix parts
 - a score of at least `70`
 
-This allows date-suffixed variants such as `openai/gpt-4o-2024-11-20` to match `openai/gpt-4o`, while avoiding broad matches such as `gpt` to `gpt-4o-2024-11-20`.
+This allows date-suffixed variants such as `custom/gpt-4o-2024-11-20` to match `openai/gpt-4o`, while avoiding broad matches such as `gpt` to `gpt-4o-2024-11-20`.
 
 ## Failure Behavior
 
@@ -153,9 +151,8 @@ The implementation includes tests for:
 - provider-nested models.dev schema parsing
 - flat model-id keyed models.dev schema parsing
 - exact matches
-- same-provider prefix matches
-- avoiding cross-provider model-only matches
-- allowing model-only matches only when no provider prefix is present
+- model-name-only matches across provider ids
+- strong model-name prefix matches
 - rejecting weak prefix matches
 
 Current verification:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -162,6 +162,6 @@ This setting is explicit because models.dev is an external metadata source. With
 
 This project is not affiliated with, endorsed by, or sponsored by [models.dev](https://models.dev/).
 
-When a safe match exists, models.dev metadata can add model limits and capabilities such as `tool_call`, `reasoning`, `attachment`, `structured_output`, `temperature`, and `modalities`.
+When a safe model-name match exists, models.dev metadata can add model limits and capabilities such as `tool_call`, `reasoning`, `attachment`, `structured_output`, `temperature`, and `modalities`.
 
 This means providers using `@ai-sdk/anthropic` with OpenAI-compatible backends are supported when the `baseURL` contains `/v1/`, when a provider-specific discovery endpoint is configured, or when provider-level discovery is explicitly forced on. It also means providers like DeepSeek can be discovered from a non-`/v1` baseURL as long as the models endpoint is configured explicitly.

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,247 @@
+# Release v1.0.0
+
+`v1.0.0` completes the provider-level configuration migration introduced in `v0.12.0`.
+
+This release includes a breaking change: plugin-level global discovery configuration is no longer applied at runtime. Discovery settings should now be configured under each provider at `provider.<id>.options.modelsDiscovery`.
+
+## Breaking Change
+
+Plugin-level global discovery config is now ignored:
+
+```json
+{
+  "plugin": [
+    [
+      "opencode-models-discovery",
+      {
+        "discovery": {
+          "enabled": false
+        },
+        "models": {
+          "includeRegex": ["^deepseek"]
+        },
+        "smartModelName": true
+      }
+    ]
+  ]
+}
+```
+
+Move settings to provider-level config:
+
+```json
+{
+  "provider": {
+    "example": {
+      "options": {
+        "modelsDiscovery": {
+          "enabled": false,
+          "smartModelName": true,
+          "models": {
+            "includeBy": [
+              { "field": "id", "match": "^deepseek" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The plugin still detects legacy global config. When detected, it logs a warning, shows a migration toast, and injects `/models-discovery:migrate`.
+
+## New
+
+### Provider-Level Dynamic Filters
+
+Added provider-level `models.includeBy` and `models.excludeBy` under:
+
+```text
+provider.<id>.options.modelsDiscovery.models
+```
+
+Rules support two modes:
+
+```json
+{
+  "field": "available",
+  "equals": false
+}
+```
+
+```json
+{
+  "field": "id",
+  "match": "^deepseek"
+}
+```
+
+Use `equals` for strict equality against:
+
+- `string`
+- `number`
+- `boolean`
+- `null`
+
+Use `match` for regex matching against string field values.
+
+Example:
+
+```json
+{
+  "modelsDiscovery": {
+    "models": {
+      "includeBy": [
+        { "field": "id", "match": "^deepseek" }
+      ],
+      "excludeBy": [
+        { "field": "available", "equals": false },
+        { "field": "id", "match": "embedding" }
+      ]
+    }
+  }
+}
+```
+
+### Default Discovery Environment Variable
+
+Added `OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED`.
+
+Supported truthy values:
+
+- `true`
+- `1`
+- `yes`
+- `on`
+
+Supported falsy values:
+
+- `false`
+- `0`
+- `no`
+- `off`
+
+Provider-level `modelsDiscovery.enabled` takes precedence over the environment variable.
+
+Example:
+
+```bash
+OPENCODE_MODELS_DISCOVERY_DEFAULT_ENABLED=false opencode
+```
+
+This disables discovery by default only for providers without explicit `modelsDiscovery.enabled`.
+
+### Config Helper Updates
+
+Updated `/models-discovery:config` to recommend provider-level configuration and the new `includeBy` / `excludeBy` filters.
+
+Updated `/models-discovery:migrate` to guide migration from legacy global config to provider-level config.
+
+## Changed
+
+### Legacy Global Config Handling
+
+Legacy global config is still detected, but no longer applied.
+
+Updated warning message:
+
+```text
+Global opencode-models-discovery config is no longer applied in v1.0.0. Move settings to provider.<name>.options.modelsDiscovery or run /models-discovery:migrate.
+```
+
+### Model Regex Filters
+
+Provider-level `models.includeRegex` and `models.excludeRegex` remain supported as id-only shortcuts.
+
+For new configs, prefer:
+
+```json
+{
+  "includeBy": [
+    { "field": "id", "match": "^qwen/" }
+  ],
+  "excludeBy": [
+    { "field": "id", "match": "embedding|rerank" }
+  ]
+}
+```
+
+Existing `includeRegex` / `excludeRegex` shortcut behavior is preserved.
+
+### Documentation
+
+Updated:
+
+- `README.md`
+- `docs/configuration.md`
+- `docs/upgrading.md`
+
+Added:
+
+- `docs/config_example/README.md`
+- `docs/config_example/deepseek.md`
+- `docs/issues/v1.0.0-provider-level-config-prd.md`
+
+## Validation
+
+Validated with:
+
+```bash
+npm run typecheck
+npm run test:run
+npm run build
+npm pack --dry-run
+```
+
+Test result:
+
+```text
+3 test files passed
+64 tests passed
+```
+
+## Upgrade Notes
+
+If you use only provider-level `modelsDiscovery` config, no action should be required.
+
+If you use plugin-level global config, migrate it to each provider.
+
+Old:
+
+```json
+{
+  "plugin": [
+    [
+      "opencode-models-discovery",
+      {
+        "models": {
+          "includeRegex": ["^qwen"]
+        }
+      }
+    ]
+  ]
+}
+```
+
+New:
+
+```json
+{
+  "provider": {
+    "example": {
+      "options": {
+        "modelsDiscovery": {
+          "models": {
+            "includeBy": [
+              { "field": "id", "match": "^qwen" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+After changing OpenCode config, restart OpenCode.

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -284,7 +284,7 @@ export async function enhanceConfig(
           const owner = extractModelOwner(model.id)
           const modelConfig: any = {
             id: model.id,
-            name: smartModelNameEnabled ? formatModelName(model) : model.id,
+            name: smartModelNameEnabled ? modelInfoEnricher?.getModelName?.(model.id) ?? formatModelName(model) : model.id,
           }
 
           if (owner) {

--- a/src/utils/model-info/models-dev.ts
+++ b/src/utils/model-info/models-dev.ts
@@ -38,6 +38,9 @@ export function createModelsDevModelInfoEnricher(data: unknown): ModelInfoEnrich
     shouldSkipModel(): boolean {
       return false
     },
+    getModelName(modelId: string): string | undefined {
+      return lookupModelsDevData(modelId, cache)?.name
+    },
     applyModelInfo(modelConfig: any, modelId: string): void {
       applyModelsDevModelInfo(modelConfig, lookupModelsDevData(modelId, cache))
     },

--- a/src/utils/model-info/types.ts
+++ b/src/utils/model-info/types.ts
@@ -1,5 +1,6 @@
 export interface ModelInfoEnricher {
   shouldSkipModel(modelId: string): boolean
+  getModelName?(modelId: string): string | undefined
   applyModelInfo(modelConfig: any, modelId: string): void
 }
 

--- a/src/utils/models-dev-fetcher.ts
+++ b/src/utils/models-dev-fetcher.ts
@@ -143,45 +143,35 @@ export function lookupModelsDevData(
   const exactMatch = cache.get(modelId) ?? cache.get(modelId.toLowerCase())
   if (exactMatch) return exactMatch
 
-  const requested = splitModelId(modelId)
-  const requestedModelLower = requested.model.toLowerCase()
-  const sameProviderCandidates: Array<[string, ModelsDevModel]> = []
+  const requestedModelLower = splitModelId(modelId).model.toLowerCase()
   const allCandidates: Array<[string, ModelsDevModel]> = []
 
   for (const [key, value] of cache.entries()) {
     const candidate = splitModelId(key)
     const candidateModelLower = candidate.model.toLowerCase()
-    const entry: [string, ModelsDevModel] = [candidateModelLower, value]
-    allCandidates.push(entry)
-
-    if (requested.provider && candidate.provider === requested.provider) {
-      sameProviderCandidates.push(entry)
-    }
+    allCandidates.push([candidateModelLower, value])
   }
 
-  for (const [candidateModel, value] of sameProviderCandidates) {
-    if (candidateModel === requestedModelLower) return value
-  }
+  const exactModelMatches = allCandidates.filter(([candidateModel]) => candidateModel === requestedModelLower)
+  if (exactModelMatches.length === 1) return exactModelMatches[0]?.[1]
+  if (exactModelMatches.length > 1) return undefined
 
-  if (!requested.provider) {
-    for (const [candidateModel, value] of allCandidates) {
-      if (candidateModel === requestedModelLower) return value
-    }
-  }
-
-  const prefixCandidates = sameProviderCandidates.length > 0 ? sameProviderCandidates : requested.provider ? [] : allCandidates
   let bestMatch: ModelsDevModel | undefined
   let bestScore = 0
+  let bestScoreMatches = 0
 
-  for (const [candidateModel, value] of prefixCandidates) {
+  for (const [candidateModel, value] of allCandidates) {
     const score = calculatePrefixScore(requestedModelLower, candidateModel)
     if (score >= PREFIX_MATCH_MIN_SCORE && score > bestScore) {
       bestScore = score
       bestMatch = value
+      bestScoreMatches = 1
+    } else if (score >= PREFIX_MATCH_MIN_SCORE && score === bestScore) {
+      bestScoreMatches++
     }
   }
 
-  return bestMatch
+  return bestScoreMatches === 1 ? bestMatch : undefined
 }
 
 export const modelsDevTestUtils = {

--- a/test/models-dev-fetcher.test.ts
+++ b/test/models-dev-fetcher.test.ts
@@ -60,11 +60,28 @@ describe('models.dev fetcher', () => {
     expect(lookupModelsDevData('openai/gpt-4o-2024-11-20', cache)?.id).toBe('openai/gpt-4o')
   })
 
-  it('should avoid cross-provider model-only matches when provider is present', () => {
+  it('should match model names without requiring the provider to match', () => {
     const cache = modelsDevTestUtils.parseModelsDevData({
       openai: {
         models: {
           'shared-model': { id: 'shared-model', tool_call: true }
+        }
+      }
+    })
+
+    expect(lookupModelsDevData('custom/shared-model', cache)?.id).toBe('openai/shared-model')
+  })
+
+  it('should not match ambiguous duplicate model names', () => {
+    const cache = modelsDevTestUtils.parseModelsDevData({
+      providerA: {
+        models: {
+          'shared-model': { id: 'shared-model', tool_call: true }
+        }
+      },
+      providerB: {
+        models: {
+          'shared-model': { id: 'shared-model', tool_call: false }
         }
       }
     })
@@ -94,5 +111,22 @@ describe('models.dev fetcher', () => {
     })
 
     expect(lookupModelsDevData('openai/gpt-4o-2024-11-20', cache)).toBeUndefined()
+  })
+
+  it('should not match ambiguous tied prefix candidates', () => {
+    const cache = modelsDevTestUtils.parseModelsDevData({
+      providerA: {
+        models: {
+          'shared-model-alpha': { id: 'shared-model-alpha', tool_call: true }
+        }
+      },
+      providerB: {
+        models: {
+          'shared-model-beta': { id: 'shared-model-beta', tool_call: false }
+        }
+      }
+    })
+
+    expect(lookupModelsDevData('custom/shared-model', cache)).toBeUndefined()
   })
 })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1081,6 +1081,56 @@ describe('ModelDiscovery Plugin', () => {
       }))
     })
 
+    it('should keep raw ids when models.dev has names but smart model names are disabled', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'custom/gpt-4o', object: 'model', created: 1234567890, owned_by: 'local' }
+            ]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            openai: {
+              models: {
+                'gpt-4o': {
+                  id: 'gpt-4o',
+                  name: 'GPT-4o',
+                  tool_call: true
+                }
+              }
+            }
+          })
+        })
+
+      const config: any = {
+        provider: {
+          custom: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Custom',
+            options: {
+              baseURL: 'http://127.0.0.1:9000/v1',
+              modelsDiscovery: {
+                modelInfoFormat: 'models.dev'
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.custom.models['custom/gpt-4o']).toEqual(expect.objectContaining({
+        id: 'custom/gpt-4o',
+        name: 'custom/gpt-4o',
+        tool_call: true
+      }))
+    })
+
     it('should continue discovery when models.dev metadata cannot be fetched', async () => {
       mockFetch
         .mockResolvedValueOnce({

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1028,6 +1028,59 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.openai.models['unknown/local-model']).not.toHaveProperty('tool_call')
     })
 
+    it('should use models.dev model names for custom provider smart names', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'custom/gpt-4o', object: 'model', created: 1234567890, owned_by: 'local' }
+            ]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            openai: {
+              models: {
+                'gpt-4o': {
+                  id: 'gpt-4o',
+                  name: 'GPT-4o',
+                  tool_call: true,
+                  limit: { context: 128000 }
+                }
+              }
+            }
+          })
+        })
+
+      const config: any = {
+        provider: {
+          custom: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Custom',
+            options: {
+              baseURL: 'http://127.0.0.1:9000/v1',
+              modelsDiscovery: {
+                modelInfoFormat: 'models.dev',
+                smartModelName: true
+              }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.custom.models['custom/gpt-4o']).toEqual(expect.objectContaining({
+        id: 'custom/gpt-4o',
+        name: 'GPT-4o',
+        tool_call: true,
+        limit: { context: 128000 }
+      }))
+    })
+
     it('should continue discovery when models.dev metadata cannot be fetched', async () => {
       mockFetch
         .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Match models.dev metadata by model-name segment instead of provider-qualified id when exact ids do not match
- Avoid unsafe metadata assignment when model-name or prefix matches are ambiguous
- Use models.dev `name` for smart model display names when models.dev enrichment is enabled
- Document provider-agnostic models.dev matching behavior

## Validation
- `npm run test:run -- test/models-dev-fetcher.test.ts`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `git diff --check upstream/main..origin/main`