### PR TITLE
feat: prepend provider to smart name and fix models.dev lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -96,6 +121,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -778,7 +804,6 @@
       "version": "25.5.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -787,7 +812,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.3",
@@ -916,7 +940,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1136,7 +1159,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2097,7 +2119,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2388,7 +2409,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2465,7 +2485,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { xdgData } from 'xdg-basedir'
 import { ToastNotifier } from '../ui/toast-notifier'
-import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
+import { categorizeModel, formatModelName, extractModelOwner, formatModelPrefix, formatProviderName } from '../utils'
 import { normalizeBaseURL, discoverModelsFromProvider, discoverModelInfoFromProvider, canDiscoverModels } from '../utils/openai-compatible-api'
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
 import { getDefaultDiscoveryConfigFromEnv, getProviderModelFieldFilters, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverModelByFields, shouldDiscoverProviderWithOverride } from '../types/plugin-config'
@@ -252,9 +252,10 @@ export async function enhanceConfig(
         }
       }
 
-      const existingModels = p.models || {}
+      const existingModels = { ...(p.models || {}) }
       const discoveredModels: Record<string, any> = {}
       let chatModelsCount = 0
+      let modifiedExisting = false
 
       const hasProviderModelRegexFilter = !!providerDiscoveryConfig.models?.includeRegex?.length || !!providerDiscoveryConfig.models?.excludeRegex?.length
       const providerModelRegexFilter = getProviderModelRegexFilter(providerDiscoveryConfig, logger.child({ category: 'filtering' }))
@@ -263,15 +264,48 @@ export async function enhanceConfig(
 
       for (const model of models) {
         const modelKey = model.id
-        if (!existingModels[modelKey]) {
-          if (!shouldDiscoverModelByFields(model, providerModelFieldFilters)) {
-            continue
+
+        const matchesFields = shouldDiscoverModelByFields(model, providerModelFieldFilters)
+        const matchesRegex = !hasProviderModelRegexFilter || shouldDiscoverModel(model.id, providerModelRegexFilter)
+
+        if (!matchesFields || !matchesRegex) {
+          if (existingModels[modelKey]) {
+            delete existingModels[modelKey]
+            modifiedExisting = true
+          }
+          continue
+        }
+
+        const parts = model.id.split('/')
+        const fallbackName = formatModelName(model)
+        const buggedName = parts.length > 2 ? formatModelName({ id: parts[0] + '/' + parts[1] } as any) : null
+
+        let newName = model.id
+        let rawSmartName = fallbackName
+        if (smartModelNameEnabled) {
+          rawSmartName = modelInfoEnricher?.getModelName?.(model.id) ?? fallbackName
+          const formattedPrefix = formatModelPrefix(model.id)
+          newName = formattedPrefix ? `${formattedPrefix} - ${rawSmartName}` : rawSmartName
+        }
+
+        if (existingModels[modelKey]) {
+          const currentModel = existingModels[modelKey]
+          const isGenericName = currentModel.name === model.id || 
+                                (buggedName && currentModel.name === buggedName) ||
+                                (smartModelNameEnabled && currentModel.name === fallbackName) ||
+                                (smartModelNameEnabled && currentModel.name === rawSmartName)
+
+          if (isGenericName && currentModel.name !== newName) {
+            currentModel.name = newName
+            modifiedExisting = true
           }
 
-          if (hasProviderModelRegexFilter && !shouldDiscoverModel(model.id, providerModelRegexFilter)) {
-            continue
+          const beforeStr = JSON.stringify(currentModel)
+          modelInfoEnricher?.applyModelInfo(currentModel, model.id)
+          if (JSON.stringify(currentModel) !== beforeStr) {
+            modifiedExisting = true
           }
-
+        } else {
           const modelType = categorizeModel(model.id)
           if (modelType === 'embedding') {
             continue
@@ -284,7 +318,7 @@ export async function enhanceConfig(
           const owner = extractModelOwner(model.id)
           const modelConfig: any = {
             id: model.id,
-            name: smartModelNameEnabled ? modelInfoEnricher?.getModelName?.(model.id) ?? formatModelName(model) : model.id,
+            name: newName,
           }
 
           if (owner) {
@@ -305,7 +339,7 @@ export async function enhanceConfig(
         }
       }
 
-      if (Object.keys(discoveredModels).length > 0) {
+      if (Object.keys(discoveredModels).length > 0 || modifiedExisting) {
         p.models = {
           ...existingModels,
           ...discoveredModels,

--- a/src/utils/format-model-name.ts
+++ b/src/utils/format-model-name.ts
@@ -12,6 +12,43 @@ export function extractModelOwner(modelId: string): string | undefined {
 }
 
 /**
+ * Format model gateway and provider prefix based on segments
+ */
+export function formatModelPrefix(modelId: string): string | undefined {
+  const parts = modelId.split('/')
+  if (parts.length >= 3) {
+    const gateway = formatProviderName(parts[0])
+    const provider = formatProviderName(parts[parts.length - 2])
+    return `${gateway} - ${provider}`
+  } else if (parts.length === 2) {
+    return formatProviderName(parts[0])
+  }
+  return undefined
+}
+
+/**
+ * Format provider name for display
+ */
+export function formatProviderName(provider: string): string {
+  const lower = provider.toLowerCase()
+  if (lower === 'opencode' || lower === 'opencode-zen') {
+    return 'OpenCode'
+  }
+  if (lower === 'openai') {
+    return 'OpenAI'
+  }
+  if (lower === 'openrouter') {
+    return 'OpenRouter'
+  }
+  
+  return provider
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(token => token.charAt(0).toUpperCase() + token.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/**
  * Format model name for display using available metadata
  * Creates readable titles like "Qwen3 30B A3B" instead of "qwen/qwen3-30b-a3b"
  */
@@ -20,7 +57,7 @@ export function formatModelName(model: OpenAIModel): string {
   
   // Extract parts from model ID
   const parts = id.split('/')
-  const modelPart = parts.length > 1 ? parts[1] : parts[0]
+  const modelPart = parts.length > 1 ? parts[parts.length - 1] : parts[0]
   
   // Common acronyms that should be uppercase
   const acronyms = new Set(['gpt', 'oss', 'api', 'gguf', 'ggml', 'nomic', 'vl', 'it', 'mlx'])

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { formatModelName, extractModelOwner } from './format-model-name'
+export { formatModelName, extractModelOwner, formatModelPrefix, formatProviderName } from './format-model-name'
 
 // Categorize models by type
 export function categorizeModel(modelId: string): 'chat' | 'embedding' | 'unknown' {

--- a/src/utils/models-dev-fetcher.ts
+++ b/src/utils/models-dev-fetcher.ts
@@ -140,10 +140,16 @@ export function lookupModelsDevData(
   modelId: string,
   cache: Map<string, ModelsDevModel>
 ): ModelsDevModel | undefined {
-  const exactMatch = cache.get(modelId) ?? cache.get(modelId.toLowerCase())
+  let cleanId = modelId.replace(/:[a-zA-Z0-9_-]+$/g, '')
+  const parts = cleanId.split('/')
+  if (parts.length > 2) {
+    cleanId = parts.slice(-2).join('/')
+  }
+
+  const exactMatch = cache.get(cleanId) ?? cache.get(cleanId.toLowerCase())
   if (exactMatch) return exactMatch
 
-  const requestedModelLower = splitModelId(modelId).model.toLowerCase()
+  const requestedModelLower = splitModelId(cleanId).model.toLowerCase()
   const allCandidates: Array<[string, ModelsDevModel]> = []
 
   for (const [key, value] of cache.entries()) {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1075,7 +1075,7 @@ describe('ModelDiscovery Plugin', () => {
 
       expect(config.provider.custom.models['custom/gpt-4o']).toEqual(expect.objectContaining({
         id: 'custom/gpt-4o',
-        name: 'GPT-4o',
+        name: 'Custom - GPT-4o',
         tool_call: true,
         limit: { context: 128000 }
       }))
@@ -1298,7 +1298,7 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toEqual(
         expect.objectContaining({
           id: 'qwen/qwen3-30b-a3b',
-          name: 'Qwen3 30B A3B'
+          name: 'Qwen - Qwen3 30B A3B'
         })
       )
     })
@@ -1857,7 +1857,7 @@ describe('ModelDiscovery Plugin', () => {
 
       expect(config.provider.ollama.models['qwen/qwen3-30b-a3b']).toEqual(
         expect.objectContaining({
-          name: 'Qwen3 30B A3B'
+          name: 'Qwen - Qwen3 30B A3B'
         })
       )
       expect(config.provider.ollama.models['bge-m3']).toBeUndefined()
@@ -2129,6 +2129,44 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.gateway.models['deepseek-reasoner']).toBeDefined()
       expect(config.provider.gateway.models['deepseek-embedding']).toBeUndefined()
       expect(config.provider.gateway.models['qwen-chat']).toBeUndefined()
+    })
+
+    it('should filter/remove existing models that do not match the includeBy / excludeBy filters', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'llama-3-8b', object: 'model', created: 1234567890, owned_by: 'local' },
+            { id: 'qwen-7b', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+
+      const config: any = {
+        provider: {
+          gateway: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Gateway',
+            options: {
+              baseURL: 'http://127.0.0.1:4000/v1',
+              modelsDiscovery: {
+                models: {
+                  includeBy: [{ field: 'id', match: '^llama' }]
+                }
+              }
+            },
+            models: {
+              'llama-3-8b': { id: 'llama-3-8b', name: 'Llama 3' },
+              'qwen-7b': { id: 'qwen-7b', name: 'Qwen 7B' }
+            }
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.gateway.models['llama-3-8b']).toBeDefined()
+      expect(config.provider.gateway.models['qwen-7b']).toBeUndefined()
     })
 
     it('should reject field filters that specify both equals and match', async () => {


### PR DESCRIPTION
- Fix fallback model name formatting for multi-part IDs

- Prepend formatted provider and gateway to display names (e.g. OpenRouter - Nvidia - Name)

- Normalize models.dev lookups by removing trailing colons and gateway prefixes

- Add self-healing check to repair generic/bugged model names in existing config