### PR TITLE
Add Atlas Cloud config example

### DIFF
--- a/docs/config_example/README.md
+++ b/docs/config_example/README.md
@@ -16,6 +16,7 @@ Do not paste secrets into public issues or pull requests. Configure provider cre
 
 ## Examples
 
+- [Atlas Cloud](atlascloud.md)
 - [DeepSeek](deepseek.md)
 
 ## Community Example PR Scope

--- a/docs/config_example/atlascloud.md
+++ b/docs/config_example/atlascloud.md
@@ -1,0 +1,34 @@
+# Atlas Cloud Configuration Example
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by Atlas Cloud.
+
+## Example
+
+```json
+{
+  "provider": {
+    "atlascloud": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Atlas Cloud",
+      "options": {
+        "baseURL": "https://api.atlascloud.ai/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "endpoint": "/models"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Notes
+
+- Configure credentials with OpenCode `/connect` when possible.
+- Use `ATLASCLOUD_API_KEY` only in local private configuration; do not commit API keys.
+- Atlas Cloud exposes an OpenAI-compatible model list endpoint at `/v1/models` relative to `https://api.atlascloud.ai/v1`.
+- The public Atlas Cloud model catalog was checked while preparing this example and included `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.
+- Verify the provider's current API base URL, model endpoint, pricing, data handling, regional availability, and terms before use.


### PR DESCRIPTION
## Summary
- add an Atlas Cloud community provider configuration example
- link the example from the config examples index
- keep the PR scoped to `docs/config_example/` per the repository's community example guidance

## Validation
- Parsed the Markdown JSON example with `JSON.parse`
- `git diff --check`
- Checked the Atlas Cloud public model catalog endpoint with a browser user agent; it returned 419 model ids and included `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

## Notes
- No root README changes.
- No sponsor block, logo placement, credits, partner copy, or promotional section added.
- The example includes the repository's requested provider-specific non-affiliation disclaimer and does not include secrets.
