### PR TITLE
docs: add AI-ROUTER provider configuration example

### DIFF
--- a/docs/config_example/README.md
+++ b/docs/config_example/README.md
@@ -16,6 +16,7 @@ Do not paste secrets into public issues or pull requests. Configure provider cre
 
 ## Examples
 
+- [AI-ROUTER](ai-router.md)
 - [DeepSeek](deepseek.md)
 
 ## Community Example PR Scope

--- a/docs/config_example/ai-router.md
+++ b/docs/config_example/ai-router.md
@@ -1,0 +1,32 @@
+# AI-ROUTER Configuration Example
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by [AI-ROUTER](https://ai-router.dev/).
+
+## Example
+
+```json
+{
+  "provider": {
+    "ai-router": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "AI-ROUTER",
+      "options": {
+        "baseURL": "https://api.ai-router.dev/v1",
+        "modelsDiscovery": {
+          "enabled": true
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Notes
+
+- Configure credentials with OpenCode `/connect` when possible, or through local private configuration.
+- This uses the plugin's standard `/v1/models` discovery path, which resolves to `https://api.ai-router.dev/v1/models`.
+- The example intentionally does not declare a static model list, filters, pricing, or third-party metadata. Returned models depend on the account and current API response.
+- Verify the current API base URL, model availability, pricing, terms of service, data handling, and regional availability before use.


### PR DESCRIPTION
## Summary
- Add a scoped community configuration example for AI-ROUTER.
- Link the example from `docs/config_example/README.md`.
- Use provider-level `modelsDiscovery` with `https://api.ai-router.dev/v1`, without a static model catalog, filters, pricing claims, or metadata enrichment.

## Validation
- Parsed the Markdown JSON example with `JSON.parse`.
- `git diff --check`
- Verified the public site returns HTTP 200. The protected `/v1/models` endpoint returns HTTP 401 without credentials, so the example directs users to configure credentials with OpenCode `/connect`.

## Disclosure
AI-ROUTER is maintained by the PR submitter. This contribution is limited to the documented community-example scope.