### PR TITLE
feat: prefer provider model metadata

### DIFF
--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -42,7 +42,9 @@ const defaultProviderModelStore = new ProviderModelStore()
 function applyProviderModelInfo(modelConfig: any, model: OpenAIModel): void {
   const contextWindow = typeof model.context_window === 'number' && model.context_window > 0
     ? model.context_window
-    : model.max_context_window
+    : typeof model.max_context_window === 'number' && model.max_context_window > 0
+      ? model.max_context_window
+      : model.context_length
   if (typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0) {
     modelConfig.limit = { ...modelConfig.limit, context: contextWindow }
     if (modelConfig.limit.input > contextWindow) delete modelConfig.limit.input

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -39,6 +39,42 @@ const RESOLVED_PROVIDERS_TIMEOUT_MS = 250
 const DEFAULT_LITELLM_MODEL_INFO_ENDPOINT = '/v1/model/info'
 const defaultProviderModelStore = new ProviderModelStore()
 
+function applyProviderModelInfo(modelConfig: any, model: OpenAIModel): void {
+  const contextWindow = typeof model.context_window === 'number' && model.context_window > 0
+    ? model.context_window
+    : model.max_context_window
+  if (typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0) {
+    modelConfig.limit = { ...modelConfig.limit, context: contextWindow }
+    if (modelConfig.limit.input > contextWindow) delete modelConfig.limit.input
+  }
+
+  const reasoningLevels = Array.isArray(model.supported_reasoning_levels)
+    ? model.supported_reasoning_levels
+      .map((level) => typeof level === 'string' ? level : level?.effort)
+      .filter((level): level is string => typeof level === 'string' && level.length > 0)
+    : []
+  if (reasoningLevels.length > 0) {
+    modelConfig.reasoning = true
+    modelConfig.variants = Object.fromEntries(
+      reasoningLevels.map((level) => [level, { reasoningEffort: level }])
+    )
+  }
+
+  if (typeof model.default_reasoning_level === 'string' && model.default_reasoning_level.length > 0) {
+    modelConfig.options = {
+      ...modelConfig.options,
+      reasoningEffort: model.default_reasoning_level,
+    }
+  }
+
+  const inputModalities = Array.isArray(model.input_modalities)
+    ? model.input_modalities.filter((modality): modality is string => typeof modality === 'string')
+    : []
+  if (inputModalities.length > 0) {
+    modelConfig.modalities = { ...modelConfig.modalities, input: inputModalities }
+  }
+}
+
 export const providerModelStoreTestUtils = {
   setStore(store: ProviderModelStore): void {
     currentProviderModelStore = store
@@ -364,6 +400,7 @@ export async function enhanceConfig(
           }
 
           modelInfoEnricher?.applyModelInfo(modelConfig, model.id, model)
+          applyProviderModelInfo(modelConfig, model)
           discoveredModels[modelKey] = modelConfig
         }
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -77,6 +77,18 @@ function applyProviderModelInfo(modelConfig: any, model: OpenAIModel): void {
   }
 }
 
+function ensureModelLimitOutput(models: Record<string, any>): void {
+  for (const model of Object.values(models)) {
+    if (!model?.limit || typeof model.limit !== 'object' || Array.isArray(model.limit)) {
+      continue
+    }
+
+    if (typeof model.limit.output !== 'number') {
+      model.limit = { ...model.limit, output: 0 }
+    }
+  }
+}
+
 export const providerModelStoreTestUtils = {
   setStore(store: ProviderModelStore): void {
     currentProviderModelStore = store
@@ -251,6 +263,7 @@ export async function enhanceConfig(
 
     for (const [providerName, providerConfig] of Object.entries(providers)) {
       const p = providerConfig as any
+      ensureModelLimitOutput(p.models || {})
       const providerDiscoveryConfig = p.options?.modelsDiscovery ?? {}
       const modelsEndpoint = providerDiscoveryConfig.endpoint ?? '/v1/models'
       const modelInfoFormat = providerDiscoveryConfig.modelInfoFormat

--- a/src/utils/model-info/models-dev.ts
+++ b/src/utils/model-info/models-dev.ts
@@ -14,7 +14,7 @@ function applyModelsDevModelInfo(modelConfig: any, info: ModelsDevModel | undefi
     modelConfig.limit = {
       ...(hasUsableNumber(contextLimit) ? { context: contextLimit } : {}),
       ...(hasUsableNumber(info.limit?.input) ? { input: info.limit.input } : {}),
-      ...(hasUsableNumber(outputLimit) ? { output: outputLimit } : {}),
+      output: hasUsableNumber(outputLimit) ? outputLimit : 0,
     }
   }
 

--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -3,7 +3,35 @@ import https from 'node:https'
 import type { OpenAIModel, OpenAIModelsResponse } from '../types'
 
 const OPENAI_COMPATIBLE_MODELS_ENDPOINT = "/v1/models"
+const CLIENT_MODELS_ENDPOINT = "/v1/models?client_version="
 const REQUEST_TIMEOUT_MS = 3000
+
+const hasUsableNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+function mergeClientModelMetadata(model: OpenAIModel, clientModels: Record<string, unknown>[]): OpenAIModel {
+  const metadata = clientModels.find((candidate) => {
+    const id = typeof candidate.id === 'string' ? candidate.id : candidate.slug
+    return typeof id === 'string' && (model.id === id || model.id.endsWith(`/${id}`))
+  })
+  if (!metadata) return model
+
+  const merged = { ...model }
+  const contextWindow = hasUsableNumber(metadata.context_window)
+    ? metadata.context_window
+    : metadata.max_context_window
+  if (hasUsableNumber(contextWindow)) merged.context_window = contextWindow
+  if (typeof metadata.default_reasoning_level === 'string') {
+    merged.default_reasoning_level = metadata.default_reasoning_level
+  }
+  if (Array.isArray(metadata.supported_reasoning_levels)) {
+    merged.supported_reasoning_levels = metadata.supported_reasoning_levels
+  }
+  if (Array.isArray(metadata.input_modalities)) {
+    merged.input_modalities = metadata.input_modalities
+  }
+  return merged
+}
 
 export interface ModelsDiscoveryResult {
   ok: boolean
@@ -82,7 +110,19 @@ export async function discoverModelsFromProvider(
   }
 
   const data = await requestJson<OpenAIModelsResponse>(url, headers)
-  return data ? { ok: true, models: data.data ?? [] } : { ok: false, models: [] }
+  if (!data) return { ok: false, models: [] }
+
+  const models = data.data ?? []
+  if (endpoint !== OPENAI_COMPATIBLE_MODELS_ENDPOINT || models.length === 0) {
+    return { ok: true, models }
+  }
+
+  const clientData = await requestJson<{ models?: Record<string, unknown>[] }>(
+    buildAPIURL(baseURL, CLIENT_MODELS_ENDPOINT),
+    headers
+  )
+  const clientModels = Array.isArray(clientData?.models) ? clientData.models : []
+  return { ok: true, models: models.map((model) => mergeClientModelMetadata(model, clientModels)) }
 }
 
 export async function discoverModelInfoFromProvider(

--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -10,16 +10,15 @@ const hasUsableNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0
 
 function mergeClientModelMetadata(model: OpenAIModel, clientModels: Record<string, unknown>[]): OpenAIModel {
-  const metadata = clientModels.find((candidate) => {
-    const id = typeof candidate.id === 'string' ? candidate.id : candidate.slug
-    return typeof id === 'string' && (model.id === id || model.id.endsWith(`/${id}`))
-  })
+  const metadata = clientModels.find((candidate) => candidate.id === model.id || candidate.slug === model.id)
   if (!metadata) return model
 
   const merged = { ...model }
   const contextWindow = hasUsableNumber(metadata.context_window)
     ? metadata.context_window
-    : metadata.max_context_window
+    : hasUsableNumber(metadata.max_context_window)
+      ? metadata.max_context_window
+      : metadata.context_length
   if (hasUsableNumber(contextWindow)) merged.context_window = contextWindow
   if (typeof metadata.default_reasoning_level === 'string') {
     merged.default_reasoning_level = metadata.default_reasoning_level

--- a/test/openai-compatible-api.test.ts
+++ b/test/openai-compatible-api.test.ts
@@ -52,19 +52,26 @@ describe('OpenAI-compatible API discovery', () => {
             }],
           }
         : {
-            models: [{
-              slug: 'gpt-5.6-terra',
-              context_window: 372000,
-              default_reasoning_level: 'medium',
-              supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium' }, { effort: 'high' }],
-              input_modalities: ['text', 'image'],
-            }],
+            models: [
+              {
+                slug: 'gpt-5.6-terra',
+                context_window: 372000,
+                default_reasoning_level: 'low',
+              },
+              {
+                slug: 'kiro/gpt-5.6-terra',
+                context_length: 272000,
+                default_reasoning_level: 'medium',
+                supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium' }, { effort: 'high' }],
+                input_modalities: ['text', 'image'],
+              }
+            ],
           }))
     }, async (baseURL) => {
       const result = await discoverModelsFromProvider(baseURL)
 
       expect(result.models[0]).toEqual(expect.objectContaining({
-        context_window: 372000,
+        context_window: 272000,
         default_reasoning_level: 'medium',
         supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium' }, { effort: 'high' }],
         input_modalities: ['text', 'image'],

--- a/test/openai-compatible-api.test.ts
+++ b/test/openai-compatible-api.test.ts
@@ -26,18 +26,49 @@ describe('OpenAI-compatible API discovery', () => {
 
   it('returns discovered models from the low-level http client', async () => {
     await withServer((req, res) => {
-      expect(req.url).toBe('/v1/models')
       res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({
-        data: [
-          { id: 'local-model', object: 'model', created: 0, owned_by: 'local' },
-        ],
-      }))
+      res.end(JSON.stringify(req.url === '/v1/models'
+        ? { data: [{ id: 'local-model', object: 'model', created: 0, owned_by: 'local' }] }
+        : { models: [] }))
     }, async (baseURL) => {
       const result = await discoverModelsFromProvider(baseURL)
 
       expect(result.ok).toBe(true)
       expect(result.models.map(model => model.id)).toEqual(['local-model'])
+    })
+  })
+
+  it('uses provider client metadata for matching models', async () => {
+    await withServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify(req.url === '/v1/models'
+        ? {
+            data: [{
+              id: 'kiro/gpt-5.6-terra',
+              object: 'model',
+              created: 0,
+              owned_by: 'local',
+              context_window: 272000,
+            }],
+          }
+        : {
+            models: [{
+              slug: 'gpt-5.6-terra',
+              context_window: 372000,
+              default_reasoning_level: 'medium',
+              supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium' }, { effort: 'high' }],
+              input_modalities: ['text', 'image'],
+            }],
+          }))
+    }, async (baseURL) => {
+      const result = await discoverModelsFromProvider(baseURL)
+
+      expect(result.models[0]).toEqual(expect.objectContaining({
+        context_window: 372000,
+        default_reasoning_level: 'medium',
+        supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium' }, { effort: 'high' }],
+        input_modalities: ['text', 'image'],
+      }))
     })
   })
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1155,6 +1155,68 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.openai.models['unknown/local-model']).not.toHaveProperty('tool_call')
     })
 
+    it('should prefer provider model metadata over external enrichment', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [{
+              id: 'custom/gpt-5.6-terra',
+              object: 'model',
+              created: 1234567890,
+              owned_by: 'local',
+              context_window: 372000,
+              default_reasoning_level: 'medium',
+              supported_reasoning_levels: ['low', 'medium', 'high', 'xhigh'],
+              input_modalities: ['text', 'image'],
+            }]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            openai: {
+              models: {
+                'gpt-5.6-terra': {
+                  id: 'gpt-5.6-terra',
+                  reasoning: false,
+                  modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+                  limit: { context: 1050000, input: 922000, output: 128000 }
+                }
+              }
+            }
+          })
+        })
+
+      const config: any = {
+        provider: {
+          custom: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:9000/v1',
+              modelsDiscovery: { modelInfoFormat: 'models.dev' }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.custom.models['custom/gpt-5.6-terra']).toEqual(expect.objectContaining({
+        reasoning: true,
+        options: { reasoningEffort: 'medium' },
+        variants: {
+          low: { reasoningEffort: 'low' },
+          medium: { reasoningEffort: 'medium' },
+          high: { reasoningEffort: 'high' },
+          xhigh: { reasoningEffort: 'xhigh' }
+        },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        limit: { context: 372000, output: 128000 }
+      }))
+    })
+
     it('should use models.dev display names for custom provider smart names', async () => {
       mockFetch
         .mockResolvedValueOnce({

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1217,6 +1217,49 @@ describe('ModelDiscovery Plugin', () => {
       }))
     })
 
+    it('should set an unknown models.dev output limit to zero', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [{ id: 'openai/gpt-image-1.5', object: 'model', created: 1234567890, owned_by: 'openai' }]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            openai: {
+              models: {
+                'gpt-image-1.5': {
+                  id: 'gpt-image-1.5',
+                  limit: { context: 272000 }
+                }
+              }
+            }
+          })
+        })
+
+      const config: any = {
+        provider: {
+          openai: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:9000/v1',
+              modelsDiscovery: { modelInfoFormat: 'models.dev' }
+            },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.openai.models['openai/gpt-image-1.5'].limit).toEqual({
+        context: 272000,
+        output: 0
+      })
+    })
+
     it('should use models.dev display names for custom provider smart names', async () => {
       mockFetch
         .mockResolvedValueOnce({
@@ -1266,7 +1309,7 @@ describe('ModelDiscovery Plugin', () => {
         id: 'custom/gpt-4o',
         name: 'GPT-4o',
         tool_call: true,
-        limit: { context: 128000 }
+        limit: { context: 128000, output: 0 }
       }))
     })
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -528,6 +528,40 @@ describe('ModelDiscovery Plugin', () => {
       expect(mockClient.config.providers).not.toHaveBeenCalled()
     })
 
+    it('repairs inherited models with a context-only limit during reload', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'qodercn/qmodel_preview', object: 'model', created: 1234567890, owned_by: 'local' }],
+        }),
+      })
+
+      const config: any = {
+        provider: {
+          cpa: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:8000/v1',
+              modelsDiscovery: { enabled: true },
+            },
+            models: {
+              'qodercn/qmodel_preview': {
+                id: 'qodercn/qmodel_preview',
+                limit: { context: 180000 },
+              },
+            },
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.cpa.models['qodercn/qmodel_preview'].limit).toEqual({
+        context: 180000,
+        output: 0,
+      })
+    })
+
     it('persists only filtered enriched models and reuses their metadata', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,


### PR DESCRIPTION
## Summary
- use provider-reported context windows, reasoning levels, defaults, and input modalities
- enrich matching models from `/v1/models?client_version=` when available
- preserve exact model IDs and keep existing metadata sources as fallback

## Why
Custom providers and distributors can expose limits that differ from public model metadata, such as deployments through AWS or Azure. Using provider-reported metadata makes discovery reflect the actual upstream deployment.

## Testing
- `npm test -- --run` (90 tests)
- `npm run typecheck`