### PR TITLE
feat: add LM Studio model metadata enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ opencode-debug.log
 coverage/
 opencode.json
 docs/articles/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ opencode-debug.log
 coverage/
 opencode.json
 docs/articles/
+.idea/

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ For LiteLLM-compatible model info endpoints, `/v1/model/info` is used by default
 }
 ```
 
+For LM Studio's native REST inventory and metadata endpoint:
+
+```json
+{
+  "modelsDiscovery": {
+    "enabled": true,
+    "modelInfoFormat": "lmstudio"
+  }
+}
+```
+
 If metadata cannot be fetched or matched safely, discovery still succeeds and the plugin leaves unknown capability fields unset rather than guessing defaults. See [`docs/providers.md`](docs/providers.md#modelsdev-metadata-enrichment) for details.
 
 ## Upgrade Note

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For LiteLLM-compatible model info endpoints, `/v1/model/info` is used by default
 }
 ```
 
-For LM Studio's native REST inventory and metadata endpoint:
+For LM Studio 0.4.0+'s native v1 REST inventory endpoint:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ Each provider can configure discovery behavior through `provider.<name>.options.
 | `provider.<name>.options.modelsDiscovery.enabled` | `boolean` | Force enable or disable discovery for a single provider |
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
 | `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Override the LiteLLM model-info endpoint path. Defaults to `/v1/model/info` when `modelInfoFormat` is `"litellm"` |
-| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"litellm"`, `"models.dev"`, and `"vllm"` |
+| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"litellm"`, `"models.dev"`, `"vllm"`, and `"lmstudio"` |
 | `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true` |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Shortcut regex allow-list for discovered model ids only |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Shortcut regex deny-list for discovered model ids only |
@@ -183,7 +183,7 @@ The plugin currently supports four model info formats:
 | `"litellm"` | Provider-specific model info endpoint | No | Uses `/v1/model/info` by default; set `modelInfoEndpoint` to override it |
 | `"models.dev"` | `https://models.dev/models.json` | No | Uses the public models.dev metadata index |
 | `"vllm"` | Fields in the provider's `/v1/models` response | No | Reads vLLM-style `max_model_len` when present |
-| `"lmstudio"` | LM Studio `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
+| `"lmstudio"` | LM Studio 0.4.0+ `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
 
 ### LiteLLM Model Info
 
@@ -249,7 +249,7 @@ For each discovered model with a positive numeric `max_model_len`, the plugin se
 
 ### LM Studio Model Info
 
-Use `modelInfoFormat: "lmstudio"` to discover models through `/v1/models` and enrich them from `/api/v1/models`. Set `modelInfoEndpoint` only when LM Studio uses another inventory path.
+Use `modelInfoFormat: "lmstudio"` with LM Studio 0.4.0+, which officially released the native v1 REST API and `GET /api/v1/models`, to discover models through `/v1/models` and enrich them from `/api/v1/models`. Set `modelInfoEndpoint` only when LM Studio uses another inventory path.
 
 ```json
 {
@@ -273,7 +273,7 @@ Use `modelInfoFormat: "lmstudio"` to discover models through `/v1/models` and en
 
 Only models returned by `/v1/models` are injected. A model is enriched only when its `id` exactly matches an inventory `key`; inventory-only models are not injected. `modelsDiscovery.endpoint` controls discovery, while `modelsDiscovery.modelInfoEndpoint` controls the inventory request.
 
-When available, the plugin sets context and output limits from the largest loaded instance `config.context_length`; otherwise it uses `max_context_length`. It also maps `capabilities.vision` to image input, `capabilities.trained_for_tool_use` to `tool_call`, and reported reasoning options to `reasoning` plus `low`, `medium`, and `high` variants. Missing or malformed metadata is left unset without preventing discovery.
+When available, the plugin sets `limit.context` from the largest loaded instance `config.context_length`, otherwise it uses `max_context_length`; it does not infer `limit.output`. The plugin maps `capabilities.vision` to image input, `capabilities.trained_for_tool_use` to `tool_call`, and reported reasoning options to `reasoning` plus `low`, `medium`, and `high` variants. Missing or malformed metadata is left unset without preventing discovery.
 
 ### models.dev Metadata
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,13 +176,14 @@ Community provider examples live in [`docs/config_example/`](config_example/).
 
 The generic OpenAI-compatible `/v1/models` endpoint only guarantees a small model list shape. Extra metadata such as context limits, tool calling, reasoning, image input, or structured output is provider-specific, so metadata enrichment is opt-in.
 
-The plugin currently supports three model info formats:
+The plugin currently supports four model info formats:
 
 | Format | Source | Requires `modelInfoEndpoint` | Notes |
 |--------|--------|------------------------------|-------|
 | `"litellm"` | Provider-specific model info endpoint | No | Uses `/v1/model/info` by default; set `modelInfoEndpoint` to override it |
 | `"models.dev"` | `https://models.dev/models.json` | No | Uses the public models.dev metadata index |
 | `"vllm"` | Fields in the provider's `/v1/models` response | No | Reads vLLM-style `max_model_len` when present |
+| `"lmstudio"` | LM Studio `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
 
 ### LiteLLM Model Info
 
@@ -245,6 +246,34 @@ Use `modelInfoFormat: "vllm"` for a vLLM-compatible provider whose `/v1/models` 
 For each discovered model with a positive numeric `max_model_len`, the plugin sets `limit.context` and `limit.output` to that value. `max_model_len` represents the total request sequence length shared by prompt and generated tokens; it is not used as an independent input limit.
 
 `max_model_len` is not part of the standard OpenAI-compatible `/v1/models` response. If a vLLM deployment or proxy does not expose it, discovery still succeeds but no limit is added. This format does not infer reasoning, tool-calling, modalities, or other capabilities.
+
+### LM Studio Model Info
+
+Use `modelInfoFormat: "lmstudio"` to discover models through `/v1/models` and enrich them from `/api/v1/models`. Set `modelInfoEndpoint` only when LM Studio uses another inventory path.
+
+```json
+{
+  "plugin": ["opencode-models-discovery"],
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "modelInfoFormat": "lmstudio"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+Only models returned by `/v1/models` are injected. A model is enriched only when its `id` exactly matches an inventory `key`; inventory-only models are not injected. `modelsDiscovery.endpoint` controls discovery, while `modelsDiscovery.modelInfoEndpoint` controls the inventory request.
+
+When available, the plugin sets context and output limits from the largest loaded instance `config.context_length`; otherwise it uses `max_context_length`. It also maps `capabilities.vision` to image input, `capabilities.trained_for_tool_use` to `tool_call`, and reported reasoning options to `reasoning` plus `low`, `medium`, and `high` variants. Missing or malformed metadata is left unset without preventing discovery.
 
 ### models.dev Metadata
 

--- a/src/plugin/commands.ts
+++ b/src/plugin/commands.ts
@@ -120,6 +120,7 @@ Supported plugin options under provider.<id>.options.modelsDiscovery:
 - modelInfoFormat="models.dev": enrich from the public models.dev index without modelInfoEndpoint
 - modelInfoFormat="litellm": enrich from a LiteLLM-compatible /v1/model/info endpoint; modelInfoEndpoint optionally overrides the path
 - modelInfoFormat="vllm": for vLLM-compatible providers whose raw /v1/models entries include a positive numeric max_model_len; without another request, sets limit.context and limit.output for matching discovered models
+- modelInfoFormat="lmstudio": discover callable models through the normal /v1/models endpoint, then enrich exact model-id matches from LM Studio's /api/v1/models inventory
 - filterNonChat: when LiteLLM model info is available, skip non-chat models by default
 - cache.enabled: opt in to a provider-scoped persisted discovery cache of filtered and enriched model configurations; defaults to false
 - cache.ttlSeconds: non-negative finite cache lifetime in seconds; defaults to 86400
@@ -142,6 +143,7 @@ Recommended defaults:
 - use modelInfoFormat="models.dev" for models.dev metadata enrichment
 - use modelInfoFormat="litellm" for LiteLLM-compatible /v1/model/info; set modelInfoEndpoint only when the provider uses another path
 - use modelInfoFormat="vllm" only when the provider's /v1/models response exposes max_model_len; it is not a standard OpenAI-compatible field, does not require modelInfoEndpoint, and does not infer other capabilities
+- use modelInfoFormat="lmstudio" for LM Studio REST metadata enrichment; set modelInfoEndpoint only when LM Studio uses another inventory path
 - configure caching only when the user requests it; it is disabled by default
 - the persisted discovery cache belongs to this plugin and is not a replacement for opencode.json
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -37,6 +37,7 @@ type HostClient = 'opencode' | 'mimocode'
 
 const RESOLVED_PROVIDERS_TIMEOUT_MS = 250
 const DEFAULT_LITELLM_MODEL_INFO_ENDPOINT = '/v1/model/info'
+const DEFAULT_LMSTUDIO_MODELS_ENDPOINT = '/api/v1/models'
 const defaultProviderModelStore = new ProviderModelStore()
 
 export const providerModelStoreTestUtils = {
@@ -302,6 +303,19 @@ export async function enhanceConfig(
         })
       } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.VLLM) {
         modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, null)
+      } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.LMStudio) {
+        const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_LMSTUDIO_MODELS_ENDPOINT
+        const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)
+        if (modelInfoDiscovery.ok) {
+          modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, modelInfoDiscovery.data)
+        } else {
+          logger.warn('Provider model info discovery failed', {
+            provider: providerName,
+            baseURL,
+            endpoint: modelInfoEndpoint,
+            format: modelInfoFormat,
+          })
+        }
       } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.LiteLLM) {
         const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_LITELLM_MODEL_INFO_ENDPOINT
         const modelInfoDiscovery = await discoverModelInfoFromProvider(baseURL, apiKey, modelInfoEndpoint)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,5 +50,24 @@ export interface ModelLoadingState {
   error?: string
 }
 
-export type LMStudioModel = OpenAIModel
-export type LMStudioModelsResponse = OpenAIModelsResponse
+export interface LMStudioLoadedInstance {
+  config?: {
+    context_length?: number
+  }
+}
+
+export interface LMStudioCapabilities {
+  vision?: boolean
+  trained_for_tool_use?: boolean
+  reasoning?: {
+    allowed_options?: string[]
+  }
+}
+
+export interface LMStudioInventoryModel {
+  key?: string
+  display_name?: string
+  loaded_instances?: LMStudioLoadedInstance[]
+  max_context_length?: number
+  capabilities?: LMStudioCapabilities
+}

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -33,6 +33,7 @@ export enum ModelInfoFormat {
   LiteLLM = 'litellm',
   ModelsDev = 'models.dev',
   VLLM = 'vllm',
+  LMStudio = 'lmstudio',
 }
 
 export const DEFAULT_CACHE_TTL_SECONDS = 86400

--- a/src/utils/model-info/index.ts
+++ b/src/utils/model-info/index.ts
@@ -1,4 +1,5 @@
 import { createLiteLLMModelInfoEnricher } from './litellm'
+import { createLMStudioModelInfoEnricher } from './lmstudio'
 import { createModelsDevModelInfoEnricher } from './models-dev'
 import { createVLLMModelInfoEnricher } from './vllm'
 import { ModelInfoFormat } from '../../types/plugin-config'
@@ -10,6 +11,7 @@ const MODEL_INFO_ENRICHERS: Partial<Record<ModelInfoFormat, ModelInfoEnricherFac
   [ModelInfoFormat.LiteLLM]: createLiteLLMModelInfoEnricher,
   [ModelInfoFormat.ModelsDev]: createModelsDevModelInfoEnricher,
   [ModelInfoFormat.VLLM]: createVLLMModelInfoEnricher,
+  [ModelInfoFormat.LMStudio]: createLMStudioModelInfoEnricher,
 }
 
 export function createModelInfoEnricher(

--- a/src/utils/model-info/lmstudio.ts
+++ b/src/utils/model-info/lmstudio.ts
@@ -51,7 +51,7 @@ export function createLMStudioModelInfoEnricher(data: unknown): ModelInfoEnriche
 
       const contextLimit = getLoadedContextLimit(model) ?? (hasUsableNumber(model.max_context_length) ? model.max_context_length : undefined)
       if (contextLimit) {
-        modelConfig.limit = { context: contextLimit, output: contextLimit }
+        modelConfig.limit = { context: contextLimit }
       }
 
       const capabilities = model.capabilities && typeof model.capabilities === 'object'

--- a/src/utils/model-info/lmstudio.ts
+++ b/src/utils/model-info/lmstudio.ts
@@ -1,0 +1,82 @@
+import type { LMStudioInventoryModel } from '../../types'
+import type { ModelInfoEnricher } from './types'
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function getModelKey(model: LMStudioInventoryModel): string | undefined {
+  return typeof model.key === 'string' && model.key.length > 0 ? model.key : undefined
+}
+
+function getLoadedContextLimit(model: LMStudioInventoryModel): number | undefined {
+  const limits = (model.loaded_instances ?? [])
+    .map(instance => instance.config?.context_length)
+    .filter(hasUsableNumber)
+
+  return limits.length > 0 ? Math.max(...limits) : undefined
+}
+
+function getReasoningOptions(model: LMStudioInventoryModel): string[] {
+  return model.capabilities?.reasoning?.allowed_options ?? []
+}
+
+function getModelInfo(models: Map<string, LMStudioInventoryModel>, modelId: string): LMStudioInventoryModel | undefined {
+  return models.get(modelId)
+}
+
+export function createLMStudioModelInfoEnricher(data: unknown): ModelInfoEnricher {
+  const models = new Map<string, LMStudioInventoryModel>()
+  const inventory = data as { models?: unknown[] } | undefined
+  if (Array.isArray(inventory?.models)) {
+    for (const model of inventory.models) {
+      if (!model || typeof model !== 'object') continue
+      const typedModel = model as LMStudioInventoryModel
+      const key = getModelKey(typedModel)
+      if (key) models.set(key, typedModel)
+    }
+  }
+
+  return {
+    shouldSkipModel(): boolean {
+      return false
+    },
+    getModelName(modelId: string): string | undefined {
+      const displayName = getModelInfo(models, modelId)?.display_name
+      return typeof displayName === 'string' && displayName.length > 0 ? displayName : undefined
+    },
+    applyModelInfo(modelConfig: any, modelId: string): void {
+      const model = getModelInfo(models, modelId)
+      if (!model) return
+
+      const contextLimit = getLoadedContextLimit(model) ?? (hasUsableNumber(model.max_context_length) ? model.max_context_length : undefined)
+      if (contextLimit) {
+        modelConfig.limit = { context: contextLimit, output: contextLimit }
+      }
+
+      const capabilities = model.capabilities && typeof model.capabilities === 'object'
+        ? model.capabilities as Record<string, unknown>
+        : undefined
+      if (capabilities?.vision === true) {
+        const input = Array.isArray(modelConfig.modalities?.input) ? modelConfig.modalities.input : []
+        const output = Array.isArray(modelConfig.modalities?.output) ? modelConfig.modalities.output : []
+        modelConfig.modalities = {
+          input: [...new Set([...input, 'image'])],
+          ...(output.length > 0 ? { output } : {}),
+        }
+      }
+      if (capabilities?.trained_for_tool_use === true) modelConfig.tool_call = true
+
+      const reasoningOptions = getReasoningOptions(model)
+      if (reasoningOptions.length > 0) {
+        modelConfig.reasoning = true
+        const variants = Object.fromEntries(
+          reasoningOptions
+            .filter((option): option is 'low' | 'medium' | 'high' => option === 'low' || option === 'medium' || option === 'high')
+            .map(option => [option, { reasoningEffort: option }])
+        )
+        if (Object.keys(variants).length > 0) modelConfig.variants = variants
+      }
+    },
+  }
+}

--- a/test/lmstudio-model-info.test.ts
+++ b/test/lmstudio-model-info.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+
+describe('LM Studio model info enricher', () => {
+  it('maps loaded context and capabilities from an inventory model', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LMStudio, { models: [{
+      type: 'llm',
+      key: 'google/gemma-4',
+      display_name: 'Gemma 4',
+      max_context_length: 131072,
+      loaded_instances: [{ config: { context_length: 8192 } }, { config: { context_length: 16384 } }],
+      capabilities: {
+        vision: true,
+        trained_for_tool_use: true,
+        reasoning: { allowed_options: ['off', 'on', 'low', 'high'] },
+      },
+    }] })
+    expect(enricher).toBeDefined()
+
+    const config: any = {
+      id: 'google/gemma-4',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+    enricher!.applyModelInfo(config, 'google/gemma-4')
+
+    expect(enricher!.getModelName?.('google/gemma-4')).toBe('Gemma 4')
+    expect(config.limit).toEqual({ context: 16384, output: 16384 })
+    expect(config.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+    expect(config.tool_call).toBe(true)
+    expect(config.reasoning).toBe(true)
+    expect(config.variants).toEqual({
+      low: { reasoningEffort: 'low' },
+      high: { reasoningEffort: 'high' },
+    })
+  })
+
+  it('falls back to max context length and leaves missing metadata unset', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LMStudio, { models: [{
+      type: 'llm',
+      key: 'local/model',
+      max_context_length: 4096,
+      loaded_instances: [{ config: { context_length: 0 } }],
+    }] })
+    const config: any = { id: 'local/model' }
+
+    enricher!.applyModelInfo(config, 'local/model')
+    expect(config.limit).toEqual({ context: 4096, output: 4096 })
+    expect(config.modalities).toBeUndefined()
+    expect(config.reasoning).toBeUndefined()
+    expect(config.tool_call).toBeUndefined()
+  })
+
+  it('ignores incomplete instances and unsupported reasoning options', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LMStudio, { models: [{
+      key: 'partial/model',
+      loaded_instances: [{}, { config: {} }, { config: { context_length: 2048 } }],
+      capabilities: { reasoning: { allowed_options: ['custom', 'medium'] } },
+    }] })
+    const config: any = { id: 'partial/model' }
+
+    enricher!.applyModelInfo(config, 'partial/model')
+
+    expect(config.limit).toEqual({ context: 2048, output: 2048 })
+    expect(config.reasoning).toBe(true)
+    expect(config.variants).toEqual({ medium: { reasoningEffort: 'medium' } })
+  })
+
+  it('does not enrich unknown models', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LMStudio, { models: [] })
+    const config: any = { id: 'missing' }
+
+    enricher!.applyModelInfo(config, 'missing')
+    expect(config).toEqual({ id: 'missing' })
+  })
+})

--- a/test/lmstudio-model-info.test.ts
+++ b/test/lmstudio-model-info.test.ts
@@ -25,7 +25,8 @@ describe('LM Studio model info enricher', () => {
     enricher!.applyModelInfo(config, 'google/gemma-4')
 
     expect(enricher!.getModelName?.('google/gemma-4')).toBe('Gemma 4')
-    expect(config.limit).toEqual({ context: 16384, output: 16384 })
+    expect(config.limit.context).toEqual(16384)
+    expect(config.limit.output).toBeUndefined()
     expect(config.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
     expect(config.tool_call).toBe(true)
     expect(config.reasoning).toBe(true)
@@ -45,7 +46,8 @@ describe('LM Studio model info enricher', () => {
     const config: any = { id: 'local/model' }
 
     enricher!.applyModelInfo(config, 'local/model')
-    expect(config.limit).toEqual({ context: 4096, output: 4096 })
+    expect(config.limit.context).toEqual(4096)
+    expect(config.limit.output).toBeUndefined()
     expect(config.modalities).toBeUndefined()
     expect(config.reasoning).toBeUndefined()
     expect(config.tool_call).toBeUndefined()
@@ -61,7 +63,8 @@ describe('LM Studio model info enricher', () => {
 
     enricher!.applyModelInfo(config, 'partial/model')
 
-    expect(config.limit).toEqual({ context: 2048, output: 2048 })
+    expect(config.limit.context).toEqual(2048)
+    expect(config.limit.output).toBeUndefined()
     expect(config.reasoning).toBe(true)
     expect(config.variants).toEqual({ medium: { reasoningEffort: 'medium' } })
   })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -2306,7 +2306,7 @@ describe('ModelDiscovery Plugin', () => {
       expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:1234/api/v1/models', expect.any(Object))
       expect(config.provider.lmstudio.models['qwen/qwen3']).toMatchObject({
         id: 'qwen/qwen3',
-        limit: { context: 8192, output: 8192 },
+        limit: { context: 8192 },
         tool_call: true,
       })
     })
@@ -2378,7 +2378,7 @@ describe('ModelDiscovery Plugin', () => {
       await pluginHooks.config(cachedConfig)
 
       expect(mockFetch).not.toHaveBeenCalled()
-      expect(cachedConfig.provider.lmstudio.models['qwen/qwen3'].limit).toEqual({ context: 8192, output: 8192 })
+      expect(cachedConfig.provider.lmstudio.models['qwen/qwen3'].limit).toEqual({ context: 8192 })
     })
 
     it('should reject field filters that specify both equals and match', async () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -2266,6 +2266,121 @@ describe('ModelDiscovery Plugin', () => {
       expect(config.provider.gateway.models['qwen-chat']).toBeUndefined()
     })
 
+    it('enriches OpenAI-discovered models from the LM Studio inventory endpoint', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.endsWith('/api/v1/models')) {
+          return {
+            ok: true,
+            json: async () => ({
+              models: [{
+                type: 'llm',
+                key: 'qwen/qwen3',
+                display_name: 'Qwen 3',
+                loaded_instances: [{ config: { context_length: 8192 } }],
+                capabilities: { trained_for_tool_use: true },
+              }],
+            }),
+          }
+        }
+        if (url.endsWith('/v1/models')) {
+          return { ok: true, json: async () => ({ data: [{ id: 'qwen/qwen3', object: 'model', created: 0, owned_by: 'lmstudio' }] }) }
+        }
+        return { ok: false }
+      })
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:1234/v1',
+              modelsDiscovery: { modelInfoFormat: 'lmstudio' },
+            },
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:1234/v1/models', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:1234/api/v1/models', expect.any(Object))
+      expect(config.provider.lmstudio.models['qwen/qwen3']).toMatchObject({
+        id: 'qwen/qwen3',
+        limit: { context: 8192, output: 8192 },
+        tool_call: true,
+      })
+    })
+
+    it('keeps generic discovery when LM Studio metadata discovery fails', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.endsWith('/v1/models')) {
+          return { ok: true, json: async () => ({ data: [{ id: 'generic-model', object: 'model', created: 0, owned_by: 'lmstudio' }] }) }
+        }
+        return { ok: false }
+      })
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:1234/v1',
+              modelsDiscovery: { modelInfoFormat: 'lmstudio' },
+            },
+            models: { explicit: { id: 'explicit', name: 'Explicit model' } },
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:1234/api/v1/models', expect.any(Object))
+      expect(config.provider.lmstudio.models).toEqual(expect.objectContaining({
+        explicit: { id: 'explicit', name: 'Explicit model' },
+        'generic-model': expect.objectContaining({ id: 'generic-model' }),
+      }))
+      expect(config.provider.lmstudio.models['generic-model'].limit).toBeUndefined()
+    })
+
+    it('reuses enriched LM Studio models from a fresh cache without requests', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.endsWith('/api/v1/models')) {
+          return { ok: true, json: async () => ({ models: [{ key: 'qwen/qwen3', loaded_instances: [{ config: { context_length: 8192 } }] }] }) }
+        }
+        if (url.endsWith('/v1/models')) {
+          return { ok: true, json: async () => ({ data: [{ id: 'qwen/qwen3', object: 'model', created: 0, owned_by: 'lmstudio' }] }) }
+        }
+        return { ok: false }
+      })
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:1234/v1',
+              modelsDiscovery: { modelInfoFormat: 'lmstudio', cache: { enabled: true, ttlSeconds: 60 } },
+            },
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+      mockFetch.mockClear()
+      const cachedConfig: any = {
+        provider: {
+          lmstudio: {
+            ...config.provider.lmstudio,
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(cachedConfig)
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(cachedConfig.provider.lmstudio.models['qwen/qwen3'].limit).toEqual({ context: 8192, output: 8192 })
+    })
+
     it('should reject field filters that specify both equals and match', async () => {
       const config: any = {
         provider: {


### PR DESCRIPTION
# Summary

- Add `modelInfoFormat: "lmstudio"` for enriching discovered LM Studio models from `/api/v1/models`.
- Map loaded context limits, vision, tool-use, reasoning support, and supported reasoning-effort variants into OpenCode model configuration.
- Preserve normal `/v1/models` discovery when LM Studio inventory metadata is unavailable or incomplete.
- Support overriding the LM Studio inventory path with `modelInfoEndpoint`.
- Document LM Studio metadata enrichment in the README and configuration guide.

# Validation
- Added unit coverage for metadata mapping, fallback context limits, malformed metadata, and unknown models.
- Added plugin integration coverage for enrichment, metadata-request failure fallback, and persisted-cache reuse.

# Configuration

```json
{
    "modelsDiscovery": {
        "enabled": true,
        "modelInfoFormat": "lmstudio"
    }
}
```
