### PR TITLE
fix: background discovery retry with 15s timeout and User-Agent

### DIFF
--- a/src/plugin/config-hook.ts
+++ b/src/plugin/config-hook.ts
@@ -46,7 +46,7 @@ export function createConfigHook(
       pluginConfig,
       logger.child({ category: 'discovery' })
     )
-    const timeoutMs = 5000
+    const timeoutMs = 3000
 
     try {
       await Promise.race([

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -40,6 +40,47 @@ const DEFAULT_LITELLM_MODEL_INFO_ENDPOINT = '/v1/model/info'
 const DEFAULT_LMSTUDIO_MODELS_ENDPOINT = '/api/v1/models'
 const defaultProviderModelStore = new ProviderModelStore()
 
+/**
+ * Retry a failed provider discovery in the background with increasing backoff,
+ * capped at a 30s total window. The first attempt already ran synchronously;
+ * these are follow-up attempts that re-fetch the models list and, on success,
+ * inject the models + persist the cache for the current session and next startup.
+ */
+function scheduleBackgroundDiscoveryRetry(
+  retry: () => Promise<boolean>,
+  providerName: string,
+  logger: PluginLogger
+): void {
+  const maxWindowMs = 30_000
+  const backoffMs = [3000, 6000, 9000]
+  const startedAt = Date.now()
+  let attemptIndex = 0
+
+  const tryOnce = (): void => {
+    const elapsed = Date.now() - startedAt
+    if (elapsed >= maxWindowMs) {
+      logger.warn('Provider model discovery failed after background retry window', { provider: providerName })
+      return
+    }
+
+    const delay = attemptIndex < backoffMs.length ? backoffMs[attemptIndex] : 9000
+    attemptIndex += 1
+    setTimeout(() => {
+      retry()
+        .then((ok) => {
+          if (!ok) {
+            tryOnce()
+          }
+        })
+        .catch(() => {
+          tryOnce()
+        })
+    }, delay)
+  }
+
+  tryOnce()
+}
+
 export const providerModelStoreTestUtils = {
   setStore(store: ProviderModelStore): void {
     currentProviderModelStore = store
@@ -252,6 +293,55 @@ export async function enhanceConfig(
 
       let models: OpenAIModel[] = []
       let discoveredModels: Record<string, any> = {}
+
+      // Shared retry closure: re-attempts discovery in the background after a
+      // failed first pass, then persists the cache and injects the models.
+      const runDiscoveryAndInject = async (): Promise<boolean> => {
+        try {
+          const retryDiscovery = await discoverModelsFromProvider(baseURL, apiKey, modelsEndpoint)
+          if (!retryDiscovery.ok) {
+            logger.debug('Background discovery retry returned failure', { provider: providerName })
+            return false
+          }
+
+          const retryModels = retryDiscovery.models.filter(isValidModel)
+          const retryDiscovered: Record<string, any> = {}
+          for (const model of retryModels) {
+            const modelKey = model.id
+            if (!shouldDiscoverModelByFields(model, getProviderModelFieldFilters(providerDiscoveryConfig, logger.child({ category: 'filtering' })))) {
+              continue
+            }
+            retryDiscovered[modelKey] = { id: model.id }
+          }
+
+          if (cacheEnabled) {
+            await currentProviderModelStore.saveModels(cacheIdentity, retryDiscovered, persistedState)
+          }
+
+          const modelsWithOverrides = Object.fromEntries(Object.entries(retryDiscovered).map(([modelID, model]) => [
+            modelID,
+            mergeModelOverride(model, persistedState?.overrides?.[modelID]),
+          ]))
+          p.models = {
+            ...modelsWithOverrides,
+            ...getExplicitModels(config, providerName, p.models || {}),
+          }
+          replaceInjectedModels(config, providerName, modelsWithOverrides)
+
+          logger.info('Provider model discovery succeeded (background retry)', {
+            provider: providerName,
+            count: Object.keys(retryDiscovered).length,
+          })
+          return true
+        } catch (error) {
+          logger.debug('Background discovery retry errored', {
+            provider: providerName,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return false
+        }
+      }
+
       if (cacheEnabled) {
         persistedState = await currentProviderModelStore.read(cacheIdentity)
         if (persistedState && isInventoryFresh(persistedState, ttlSeconds)) {
@@ -269,6 +359,7 @@ export async function enhanceConfig(
               baseURL,
               endpoint: modelsEndpoint,
             })
+            scheduleBackgroundDiscoveryRetry(runDiscoveryAndInject, providerName, logger)
             continue
           }
 
@@ -283,6 +374,7 @@ export async function enhanceConfig(
             baseURL,
             endpoint: modelsEndpoint,
           })
+          scheduleBackgroundDiscoveryRetry(runDiscoveryAndInject, providerName, logger)
           continue
         }
         models = discovery.models.filter(isValidModel)

--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -3,7 +3,8 @@ import https from 'node:https'
 import type { OpenAIModel, OpenAIModelsResponse } from '../types'
 
 const OPENAI_COMPATIBLE_MODELS_ENDPOINT = "/v1/models"
-const REQUEST_TIMEOUT_MS = 3000
+const REQUEST_TIMEOUT_MS = 15000
+const REQUEST_USER_AGENT = "opencode-models-discovery/1.3.0"
 
 export interface ModelsDiscoveryResult {
   ok: boolean
@@ -28,7 +29,7 @@ export function buildAPIURL(baseURL: string, endpoint: string = OPENAI_COMPATIBL
   return `${normalized}${endpoint}`
 }
 
-function requestJson<T>(urlStr: string, headers: Record<string, string>): Promise<T | undefined> {
+function requestJson<T>(urlStr: string, headers: Record<string, string>, timeoutMs: number = REQUEST_TIMEOUT_MS): Promise<T | undefined> {
   return new Promise((resolve) => {
     let settled = false
     const finish = (data: T | undefined) => {
@@ -41,7 +42,10 @@ function requestJson<T>(urlStr: string, headers: Record<string, string>): Promis
     const urlObj = new URL(urlStr)
     const mod = urlObj.protocol === 'https:' ? https : http
 
-    const req = mod.get(urlObj, { headers, timeout: REQUEST_TIMEOUT_MS }, (res) => {
+    const req = mod.get(urlObj, {
+      headers: { ...(REQUEST_USER_AGENT ? { "User-Agent": REQUEST_USER_AGENT } : {}), ...headers },
+      timeout: timeoutMs,
+    }, (res) => {
       let data = ''
       res.setEncoding('utf8')
       res.on('data', (chunk: string) => data += chunk)
@@ -71,7 +75,8 @@ function requestJson<T>(urlStr: string, headers: Record<string, string>): Promis
 export async function discoverModelsFromProvider(
   baseURL: string,
   apiKey?: string,
-  endpoint: string = OPENAI_COMPATIBLE_MODELS_ENDPOINT
+  endpoint: string = OPENAI_COMPATIBLE_MODELS_ENDPOINT,
+  timeoutMs: number = REQUEST_TIMEOUT_MS
 ): Promise<ModelsDiscoveryResult> {
   const url = buildAPIURL(baseURL, endpoint)
   const headers: Record<string, string> = {
@@ -81,7 +86,7 @@ export async function discoverModelsFromProvider(
     headers["Authorization"] = `Bearer ${apiKey}`
   }
 
-  const data = await requestJson<OpenAIModelsResponse>(url, headers)
+  const data = await requestJson<OpenAIModelsResponse>(url, headers, timeoutMs)
   return data ? { ok: true, models: data.data ?? [] } : { ok: false, models: [] }
 }
 

--- a/test/openai-compatible-api.test.ts
+++ b/test/openai-compatible-api.test.ts
@@ -81,7 +81,7 @@ describe('OpenAI-compatible API discovery', () => {
         res.end(JSON.stringify({ data: [] }))
       }, 3500)
     }, async (baseURL) => {
-      const result = await discoverModelsFromProvider(baseURL)
+      const result = await discoverModelsFromProvider(baseURL, undefined, '/v1/models', 100)
 
       expect(result).toEqual({ ok: false, models: [] })
     })


### PR DESCRIPTION
## Problem

Providers like kilo.ai, zenmux, and nararouter fail model discovery at startup:

1. **3s hardcoded request timeout** — kilo's `/v1/models` takes ~6s to respond to a request without a User-Agent (measured: 6.04s). Discovery dies at 3s, no models are discovered, no filters run, and the provider falls back to its full models.dev catalog.
2. **No User-Agent sent** — discovery requests only send `Content-Type`; some gateways deprioritize/delay UA-less requests.
3. **No retry** — a failed discovery gives up instantly; the failure path never re-attempts, so the disk cache never populates.

## Changes

- `openai-compatible-api.ts`: request timeout **3s → 15s**; add `User-Agent: opencode-models-discovery/1.3.0` header to discovery requests; make timeout injectable via `discoverModelsFromProvider(baseURL, apiKey, endpoint, timeoutMs)` (default unchanged-at-15s) so tests don't depend on the fixed value.
- `enhance-config.ts`: on discovery failure, schedule a background retry that re-runs discovery + filtering, injects models, and persists the cache — backoff 3s/6s/9s, **hard-capped at a 30s total window** (no infinite retries).
- `config-hook.ts`: startup yield **5s → 3s** — discovery continues asynchronously in the background, so the TUI starts faster.
- Test updated to pass an explicit 100ms timeout for the timeout-path test (was asserting the old 3s constant).

## Verification

- `bun run test:run`: 100/100 passing.
- Empirically measured kilo.ai `/v1/models` latency without UA: 6.04s — the 3s timeout was the root cause; 15s covers it.