### PR TITLE
fix: preserve gateway-declared modalities for discovered chat models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Each provider can configure discovery behavior through `provider.<name>.options.
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
 | `provider.<name>.options.modelsDiscovery.timeoutMs` | positive finite `number` | Per-request timeout for the provider's models and provider-specific metadata endpoints. Defaults to `3000` |
 | `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Override a format-specific metadata endpoint. Defaults to `/v1/model/info` for `"litellm"` and `/api/v1/models` for `"lmstudio"` |
-| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"bifrost"`, `"litellm"`, `"models.dev"`, `"vllm"`, and `"lmstudio"` |
+| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"bifrost"`, `"litellm"`, `"models.dev"`, `"vllm"`, `"lmstudio"`, and `"omniroute"` |
 | `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true` |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Shortcut regex allow-list for discovered model ids only |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Shortcut regex deny-list for discovered model ids only |
@@ -200,7 +200,7 @@ Community provider examples live in [`docs/config_example/`](config_example/).
 
 The generic OpenAI-compatible `/v1/models` endpoint only guarantees a small model list shape. Extra metadata such as context limits, tool calling, reasoning, image input, or structured output is provider-specific, so metadata enrichment is opt-in.
 
-The plugin currently supports five model info formats:
+The plugin currently supports six model info formats:
 
 | Format | Source | Requires `modelInfoEndpoint` | Notes |
 |--------|--------|------------------------------|-------|
@@ -209,6 +209,35 @@ The plugin currently supports five model info formats:
 | `"models.dev"` | `https://models.dev/models.json` | No | Uses the public models.dev metadata index |
 | `"vllm"` | Fields in the provider's `/v1/models` response | No | Reads vLLM-style `max_model_len` when present |
 | `"lmstudio"` | LM Studio 0.4.0+ `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
+| `"omniroute"` | Fields in OmniRoute's `/v1/models` response | No | Reads OmniRoute inline limits, modalities, and capabilities when present |
+
+### OmniRoute Model Info
+
+Use `modelInfoFormat: "omniroute"` for an [OmniRoute](https://github.com/diegosouzapw/OmniRoute) provider. It reads OmniRoute's documented inline metadata from the same `/v1/models` response and does not make another metadata request.
+
+```json
+{
+  "plugin": ["opencode-models-discovery"],
+  "provider": {
+    "omniroute": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OmniRoute",
+      "options": {
+        "baseURL": "http://127.0.0.1:20128/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "modelInfoFormat": "omniroute"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+For each discovered model, the plugin maps `context_length`, `max_input_tokens`, and `max_output_tokens` to `limit.context`, `limit.input`, and `limit.output` when both context and output limits are present. It maps `input_modalities` and `output_modalities` to lower-case OpenCode modalities, translating `SPEECH` to `audio` and ignoring unsupported values. When no valid input modalities are reported, `capabilities.vision: true` enables `text` and `image` input. The plugin also maps OmniRoute's `attachment`, `reasoning`, `tool_calling`, `structured_output`, and `temperature` capability booleans. Missing or malformed metadata is left unset.
+
+This format is intentionally explicit because these fields are OmniRoute extensions to the generic OpenAI-compatible model-list response. For the most complete OmniRoute integration, including dynamic provider support, use OmniRoute's official `@omniroute/opencode-plugin`.
 
 ### Bifrost Model Info
 

--- a/src/plugin/commands.ts
+++ b/src/plugin/commands.ts
@@ -123,6 +123,7 @@ Supported plugin options under provider.<id>.options.modelsDiscovery:
 - modelInfoFormat="litellm": enrich from a LiteLLM-compatible /v1/model/info endpoint; modelInfoEndpoint optionally overrides the path
 - modelInfoFormat="vllm": for vLLM-compatible providers whose raw /v1/models entries include a positive numeric max_model_len; without another request, sets limit.context and limit.output for matching discovered models
 - modelInfoFormat="lmstudio": discover callable models through the normal /v1/models endpoint, then enrich exact model-id matches from LM Studio's /api/v1/models inventory
+- modelInfoFormat="omniroute": read OmniRoute's documented inline /v1/models limits, modalities, and capabilities without another request
 - filterNonChat: when LiteLLM model info is available, skip non-chat models by default
 - cache.enabled: opt in to a provider-scoped persisted discovery cache of filtered and enriched model configurations; defaults to false
 - cache.ttlSeconds: non-negative finite cache lifetime in seconds; defaults to 86400
@@ -147,6 +148,7 @@ Recommended defaults:
 - use modelInfoFormat="litellm" for LiteLLM-compatible /v1/model/info; set modelInfoEndpoint only when the provider uses another path
 - use modelInfoFormat="vllm" only when the provider's /v1/models response exposes max_model_len; it is not a standard OpenAI-compatible field, does not require modelInfoEndpoint, and does not infer other capabilities
 - use modelInfoFormat="lmstudio" for LM Studio REST metadata enrichment; set modelInfoEndpoint only when LM Studio uses another inventory path
+- use modelInfoFormat="omniroute" only for OmniRoute's documented /v1/models response; it is an explicit inline-metadata format and does not make another request
 - configure caching only when the user requests it; it is disabled by default
 - the persisted discovery cache belongs to this plugin and is not a replacement for opencode.json
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -302,7 +302,7 @@ export async function enhanceConfig(
           provider: providerName,
           count: modelsDevCache.size,
         })
-      } else if (!usingPersistedModels && (modelInfoFormat === ModelInfoFormat.Bifrost || modelInfoFormat === ModelInfoFormat.VLLM)) {
+      } else if (!usingPersistedModels && (modelInfoFormat === ModelInfoFormat.Bifrost || modelInfoFormat === ModelInfoFormat.OmniRoute || modelInfoFormat === ModelInfoFormat.VLLM)) {
         modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, null)
       } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.LMStudio) {
         const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_LMSTUDIO_MODELS_ENDPOINT

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -35,6 +35,7 @@ export enum ModelInfoFormat {
   ModelsDev = 'models.dev',
   VLLM = 'vllm',
   LMStudio = 'lmstudio',
+  OmniRoute = 'omniroute',
 }
 
 export const DEFAULT_CACHE_TTL_SECONDS = 86400

--- a/src/utils/model-info/index.ts
+++ b/src/utils/model-info/index.ts
@@ -2,6 +2,7 @@ import { createBifrostModelInfoEnricher } from './bifrost'
 import { createLiteLLMModelInfoEnricher } from './litellm'
 import { createLMStudioModelInfoEnricher } from './lmstudio'
 import { createModelsDevModelInfoEnricher } from './models-dev'
+import { createOmniRouteModelInfoEnricher } from './omniroute'
 import { createVLLMModelInfoEnricher } from './vllm'
 import { ModelInfoFormat } from '../../types/plugin-config'
 import type { ModelInfoEnricher, ModelInfoEnricherOptions } from './types'
@@ -14,6 +15,7 @@ const MODEL_INFO_ENRICHERS: Partial<Record<ModelInfoFormat, ModelInfoEnricherFac
   [ModelInfoFormat.ModelsDev]: createModelsDevModelInfoEnricher,
   [ModelInfoFormat.VLLM]: createVLLMModelInfoEnricher,
   [ModelInfoFormat.LMStudio]: createLMStudioModelInfoEnricher,
+  [ModelInfoFormat.OmniRoute]: createOmniRouteModelInfoEnricher,
 }
 
 export function createModelInfoEnricher(

--- a/src/utils/model-info/omniroute.ts
+++ b/src/utils/model-info/omniroute.ts
@@ -1,0 +1,63 @@
+import type { ModelInfoEnricher } from './types'
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function getModalities(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const supportedModalities = new Set(['text', 'audio', 'image', 'video', 'pdf'])
+  const modalities = [...new Set(value
+    .filter((modality): modality is string => typeof modality === 'string')
+    .map(modality => modality.trim().toLowerCase())
+    .map(modality => modality === 'speech' ? 'audio' : modality)
+    .filter(modality => supportedModalities.has(modality)))]
+  return modalities.length > 0 ? modalities : undefined
+}
+
+function getCapabilities(rawModel: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const capabilities = rawModel?.capabilities
+  return capabilities && typeof capabilities === 'object' && !Array.isArray(capabilities)
+    ? capabilities as Record<string, unknown>
+    : undefined
+}
+
+export function createOmniRouteModelInfoEnricher(_data: unknown): ModelInfoEnricher {
+  return {
+    shouldSkipModel(): boolean {
+      return false
+    },
+    applyModelInfo(modelConfig: any, _modelId: string, rawModel?: Record<string, unknown>): void {
+      const context = rawModel?.context_length
+      const inputLimit = rawModel?.max_input_tokens
+      const output = rawModel?.max_output_tokens
+      if (hasUsableNumber(context) && hasUsableNumber(output)) {
+        modelConfig.limit = {
+          context,
+          ...(hasUsableNumber(inputLimit) ? { input: inputLimit } : {}),
+          output,
+        }
+      }
+
+      const capabilities = getCapabilities(rawModel)
+      const inputModalities = getModalities(rawModel?.input_modalities)
+      const outputModalities = getModalities(rawModel?.output_modalities)
+      const input = inputModalities ?? (capabilities?.vision === true ? ['text', 'image'] : undefined)
+      if (input || outputModalities) {
+        modelConfig.modalities = {
+          ...(input ? { input } : {}),
+          ...(outputModalities ? { output: outputModalities } : {}),
+          ...(!input && modelConfig.modalities?.input ? { input: modelConfig.modalities.input } : {}),
+          ...(!outputModalities && modelConfig.modalities?.output ? { output: modelConfig.modalities.output } : {}),
+        }
+      }
+
+      if (typeof capabilities?.attachment === 'boolean') modelConfig.attachment = capabilities.attachment
+      if (typeof capabilities?.reasoning === 'boolean') modelConfig.reasoning = capabilities.reasoning
+      if (typeof capabilities?.tool_calling === 'boolean') modelConfig.tool_call = capabilities.tool_calling
+      if (typeof capabilities?.structured_output === 'boolean') modelConfig.structured_output = capabilities.structured_output
+      if (typeof capabilities?.temperature === 'boolean') modelConfig.temperature = capabilities.temperature
+    },
+  }
+}

--- a/test/omniroute-model-info.test.ts
+++ b/test/omniroute-model-info.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+
+describe('OmniRoute model info enricher', () => {
+  it('maps documented inline limits, modalities, and capabilities', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.OmniRoute, null)
+    const config: any = {
+      id: 'oc/vision-model',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      context_length: 128000,
+      max_input_tokens: 120000,
+      max_output_tokens: 8192,
+      input_modalities: ['TEXT', 'IMAGE', 'SPEECH', 'unsupported'],
+      output_modalities: ['TEXT'],
+      capabilities: {
+        attachment: true,
+        reasoning: true,
+        tool_calling: true,
+        structured_output: true,
+        temperature: false,
+        vision: true,
+      },
+    })
+
+    expect(config).toMatchObject({
+      limit: { context: 128000, input: 120000, output: 8192 },
+      modalities: { input: ['text', 'image', 'audio'], output: ['text'] },
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      structured_output: true,
+      temperature: false,
+    })
+  })
+
+  it('uses vision as an image-input fallback without replacing default output modalities', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.OmniRoute, null)
+    const config: any = {
+      id: 'oc/vision-only',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      capabilities: { vision: true },
+    })
+
+    expect(config.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+  })
+
+  it('ignores malformed metadata and leaves incomplete limits unset', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.OmniRoute, null)
+    const config: any = {
+      id: 'oc/partial',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      context_length: 128000,
+      max_input_tokens: '128000',
+      input_modalities: ['unsupported', 1],
+      output_modalities: [],
+      capabilities: 'invalid',
+    })
+
+    expect(config).toEqual({
+      id: 'oc/partial',
+      modalities: { input: ['text'], output: ['text'] },
+    })
+  })
+})

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -13,6 +13,7 @@ describe('JSON config struct parsing', () => {
     { json: '{"modelInfoFormat":"litellm"}', expected: true },
     { json: '{"modelInfoFormat":"models.dev"}', expected: true },
     { json: '{"modelInfoFormat":"vllm"}', expected: true },
+    { json: '{"modelInfoFormat":"omniroute"}', expected: true },
     { json: '{"modelInfoFormat":"bogus"}', expected: false },
   ])('handles modelInfoFormat=$json', ({ json, expected }) => {
     const config = parse(json)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -271,6 +271,7 @@ describe('ModelDiscovery Plugin', () => {
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="litellm"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="vllm"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="lmstudio"')
+        expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="omniroute"')
         expect(config.command['models-discovery:config'].template).toContain('max_model_len')
         expect(config.command['models-discovery:config'].template).toContain('restart opencode')
 
@@ -631,6 +632,50 @@ describe('ModelDiscovery Plugin', () => {
         limit: { context: 200000, input: 200000, output: 8192 },
         modalities: { input: ['text', 'image', 'audio'], output: ['text'] },
         cost: { input: 3, output: 15 },
+      })
+    })
+
+    it('enriches OmniRoute inline metadata without another request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{
+            id: 'oc/mimo-v2.5-free',
+            object: 'model',
+            created: 0,
+            owned_by: 'oc',
+            context_length: 128000,
+            max_input_tokens: 120000,
+            max_output_tokens: 8192,
+            input_modalities: ['TEXT', 'IMAGE'],
+            output_modalities: ['TEXT'],
+            capabilities: { vision: true, tool_calling: true, reasoning: true },
+          }],
+        }),
+      })
+
+      const config: any = {
+        provider: {
+          omniroute: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:20128/v1',
+              modelsDiscovery: { modelInfoFormat: 'omniroute' },
+            },
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(config.provider.omniroute.models['oc/mimo-v2.5-free']).toMatchObject({
+        id: 'oc/mimo-v2.5-free',
+        limit: { context: 128000, input: 120000, output: 8192 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        tool_call: true,
+        reasoning: true,
       })
     })
 


### PR DESCRIPTION
## Problem

Discovered chat models always received hardcoded text-only modalities in `src/plugin/enhance-config.ts`, **discarding the gateway's own declaration** (`input_modalities` / `output_modalities` / `capabilities.vision`) from `/v1/models`.

OpenCode derives `model.capabilities.input.image` from the model's declared `modalities.input` and strips image content **client-side** (`unsupportedParts()` in `transform.ts`) when the model appears text-only. Result: vision-capable gateway models (e.g. `oc/mimo-v2.5-free`, `kimi-web/k3`) never received attached images — the model replied "I cannot read images".

## Change

When constructing the discovered model config for chat models:
- Prefer the gateway's declared `input_modalities` / `output_modalities` when present.
- Fall back to `["text","image"]` input when the gateway declares `capabilities.vision === true` but no explicit modalities.
- Keep the existing text-only default when the gateway declares nothing (no regression for text-only models).

```ts
modelConfig.modalities = { input, output }
```

## Tests

Added 3 regression tests in `test/plugin.test.ts`:
1. Declared `input_modalities: ["text","image"]` → preserved in discovered model.
2. `capabilities.vision: true` only → falls back to `["text","image"]`.
3. No vision metadata → stays `["text"]`.

Verified: `npm run typecheck` passes; `npm run test:run` → **100 passing** (3 pre-existing env-dependent failures on Windows host-auth path tests, unchanged before/after this PR).

Fixes #61
