### PR TITLE
feat: add omni-route model info format with models.dev fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ For models.dev enrichment:
 }
 ```
 
+For OmniRoute-style gateways that serve rich inline metadata (capabilities, effort tiers, modalities, limits, and per-million pricing) in `/v1/models`, with models.dev used as a per-field fallback:
+
+```json
+{
+  "modelsDiscovery": {
+    "enabled": true,
+    "modelInfoFormat": "omni-route"
+  }
+}
+```
+
 For LiteLLM-compatible model info endpoints, `/v1/model/info` is used by default:
 
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,13 +176,14 @@ Community provider examples live in [`docs/config_example/`](config_example/).
 
 The generic OpenAI-compatible `/v1/models` endpoint only guarantees a small model list shape. Extra metadata such as context limits, tool calling, reasoning, image input, or structured output is provider-specific, so metadata enrichment is opt-in.
 
-The plugin currently supports five model info formats:
+The plugin currently supports six model info formats:
 
 | Format | Source | Requires `modelInfoEndpoint` | Notes |
 |--------|--------|------------------------------|-------|
 | `"bifrost"` | Fields in Bifrost's `/v1/models` response | No | Reads Bifrost inline limits, modalities, and base pricing when present |
 | `"litellm"` | Provider-specific model info endpoint | No | Uses `/v1/model/info` by default; set `modelInfoEndpoint` to override it |
 | `"models.dev"` | `https://models.dev/models.json` | No | Uses the public models.dev metadata index |
+| `"omni-route"` | Fields in the gateway's `/v1/models` response, plus models.dev fallback | No | Reads OmniRoute-style inline capabilities, effort tiers, modalities, limits, and pricing; models.dev fills missing fields |
 | `"vllm"` | Fields in the provider's `/v1/models` response | No | Reads vLLM-style `max_model_len` when present |
 | `"lmstudio"` | LM Studio 0.4.0+ `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
 
@@ -374,6 +375,38 @@ For providers with custom metadata paths or non-standard behavior:
   }
 }
 ```
+
+### OmniRoute Model Info
+
+Use `modelInfoFormat: "omni-route"` for OmniRoute-style gateways whose `/v1/models` response carries rich inline metadata per model: a `capabilities` object (`reasoning`, `thinking`, `tool_calling`, `attachment`, `temperature`, `structured_output`, and `effort_tiers`), top-level `input_modalities` and `output_modalities`, `context_length` / `max_input_tokens` / `max_output_tokens`, `family`, `release_date`, and `pricing` in USD per million tokens (`input`, `output`, `cached`, `cache_creation`).
+
+```json
+{
+  "plugin": ["opencode-models-discovery"],
+  "provider": {
+    "omniroute": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OmniRoute",
+      "options": {
+        "baseURL": "https://omni-route.example.com/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "modelInfoFormat": "omni-route"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+Inline gateway metadata always wins. The models.dev index is fetched once per session (as with `modelInfoFormat: "models.dev"`) and fills gaps per field: context, input, and output limits, modalities, capability flags, and cost are taken from models.dev only when the gateway entry does not provide them.
+
+Each advertised `capabilities.effort_tiers` value becomes an OpenCode variant of the form `{ "reasoningEffort": "<tier>" }`, so every thinking level the gateway serves is selectable with the `variant_cycle` keybind. When a reasoning model does not serve effort tiers, variants still work through models.dev `reasoning_options`: effort values map to the same `reasoningEffort` variants, and `budget_tokens` options produce `high` and `max` thinking-budget variants that mirror OpenCode's built-in Anthropic-style budgets (`high` is `min(16000, output / 2 - 1)` and `max` is `min(31999, output - 1)`, never below the model's minimum budget).
+
+Because gateway model ids are often prefixed routes (for example `cc/claude-x` or `cp/vendor/model-y`), the models.dev fallback lookup first tries the last two id segments as an exact models.dev key, then matches the bare model name. If several models.dev providers serve the same bare name, the lookup deterministically prefers the first-party vendor entry (`anthropic`, `openai`, `google`, `xai`, and other original vendors) over gateway resellers, and gives up rather than guessing when no preferred provider matches.
+
+For testing or air-gapped setups, the models.dev index URL can be overridden with the `OPENCODE_MODELS_DISCOVERY_MODELS_DEV_URL` environment variable; it applies to both the `models.dev` and `omni-route` formats.
 
 ## Example Configurations
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -294,7 +294,7 @@ export async function enhanceConfig(
           provider: providerName,
           format: modelInfoFormat,
         })
-      } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.ModelsDev) {
+      } else if (!usingPersistedModels && (modelInfoFormat === ModelInfoFormat.ModelsDev || modelInfoFormat === ModelInfoFormat.OmniRoute)) {
         const modelsDevCache = await fetchModelsDevData()
         modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, modelsDevCache, { filterNonChat })
         logger.info('Loaded models.dev data', {

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -33,6 +33,7 @@ export enum ModelInfoFormat {
   Bifrost = 'bifrost',
   LiteLLM = 'litellm',
   ModelsDev = 'models.dev',
+  OmniRoute = 'omni-route',
   VLLM = 'vllm',
   LMStudio = 'lmstudio',
 }

--- a/src/utils/model-info/index.ts
+++ b/src/utils/model-info/index.ts
@@ -2,6 +2,7 @@ import { createBifrostModelInfoEnricher } from './bifrost'
 import { createLiteLLMModelInfoEnricher } from './litellm'
 import { createLMStudioModelInfoEnricher } from './lmstudio'
 import { createModelsDevModelInfoEnricher } from './models-dev'
+import { createOmniRouteModelInfoEnricher } from './omni-route'
 import { createVLLMModelInfoEnricher } from './vllm'
 import { ModelInfoFormat } from '../../types/plugin-config'
 import type { ModelInfoEnricher, ModelInfoEnricherOptions } from './types'
@@ -12,6 +13,7 @@ const MODEL_INFO_ENRICHERS: Partial<Record<ModelInfoFormat, ModelInfoEnricherFac
   [ModelInfoFormat.Bifrost]: createBifrostModelInfoEnricher,
   [ModelInfoFormat.LiteLLM]: createLiteLLMModelInfoEnricher,
   [ModelInfoFormat.ModelsDev]: createModelsDevModelInfoEnricher,
+  [ModelInfoFormat.OmniRoute]: createOmniRouteModelInfoEnricher,
   [ModelInfoFormat.VLLM]: createVLLMModelInfoEnricher,
   [ModelInfoFormat.LMStudio]: createLMStudioModelInfoEnricher,
 }

--- a/src/utils/model-info/omni-route.ts
+++ b/src/utils/model-info/omni-route.ts
@@ -1,0 +1,263 @@
+import type { ModelInfoEnricher } from './types'
+import type { ModelsDevModel } from '../models-dev-fetcher'
+
+const SUPPORTED_MODALITIES = new Set(['text', 'audio', 'image', 'video', 'pdf'])
+
+// Deterministic tie-break for models.dev fallback lookups: when a bare model
+// name is served by several models.dev providers, prefer the first-party
+// vendor entry over gateway resellers so limits and prices stay canonical.
+const FALLBACK_PROVIDER_PRECEDENCE = [
+  'anthropic',
+  'openai',
+  'google',
+  'xai',
+  'deepseek',
+  'moonshotai',
+  'zai',
+  'zhipuai',
+  'alibaba',
+  'qwen',
+  'xiaomi',
+  'minimax',
+  'mistral',
+  'meta',
+]
+
+// Mirrors OpenCode's built-in Anthropic-style thinking-budget variants.
+const HIGH_THINKING_BUDGET = 16000
+const MAX_THINKING_BUDGET = 31999
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function parseNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+function firstUsableNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (hasUsableNumber(value)) return value
+  }
+  return undefined
+}
+
+function firstBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === 'boolean') return value
+  }
+  return undefined
+}
+
+function getModalities(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const modalities = [...new Set(value
+    .filter((modality): modality is string => typeof modality === 'string')
+    .map((modality) => modality.trim().toLowerCase())
+    .map((modality) => modality === 'speech' ? 'audio' : modality)
+    .filter((modality) => SUPPORTED_MODALITIES.has(modality)))]
+  return modalities.length > 0 ? modalities : undefined
+}
+
+function getCapabilities(rawModel?: Record<string, unknown>): Record<string, unknown> | undefined {
+  const capabilities = rawModel?.capabilities
+  return isObject(capabilities) ? capabilities : undefined
+}
+
+function getEffortTiers(capabilities?: Record<string, unknown>): string[] {
+  const tiers = capabilities?.effort_tiers
+  if (!Array.isArray(tiers)) return []
+
+  return [...new Set(tiers
+    .filter((tier): tier is string => typeof tier === 'string')
+    .map((tier) => tier.trim())
+    .filter((tier) => tier.length > 0))]
+}
+
+function createEffortVariants(efforts: string[]): Record<string, { reasoningEffort: string }> {
+  return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
+}
+
+function createInlineCost(pricing: unknown): Record<string, number> | undefined {
+  if (!isObject(pricing)) return undefined
+
+  // OmniRoute pricing is USD per million tokens, matching OpenCode's cost unit.
+  const input = parseNonNegativeNumber(pricing.input)
+  const output = parseNonNegativeNumber(pricing.output)
+  if (input === undefined || output === undefined) return undefined
+
+  const cacheRead = parseNonNegativeNumber(pricing.cached)
+  const cacheWrite = parseNonNegativeNumber(pricing.cache_creation)
+  return {
+    input,
+    output,
+    ...(cacheRead !== undefined ? { cache_read: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_write: cacheWrite } : {}),
+  }
+}
+
+function createFallbackCost(cost: ModelsDevModel['cost']): Record<string, number> | undefined {
+  const input = parseNonNegativeNumber(cost?.input)
+  const output = parseNonNegativeNumber(cost?.output)
+  if (input === undefined || output === undefined) return undefined
+
+  const cacheRead = parseNonNegativeNumber(cost?.cache_read)
+  const cacheWrite = parseNonNegativeNumber(cost?.cache_write)
+  return {
+    input,
+    output,
+    ...(cacheRead !== undefined ? { cache_read: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_write: cacheWrite } : {}),
+  }
+}
+
+function splitCacheKey(key: string): { provider?: string; model: string } {
+  const separatorIndex = key.indexOf('/')
+  if (separatorIndex === -1) return { model: key }
+
+  return {
+    provider: key.slice(0, separatorIndex).toLowerCase(),
+    model: key.slice(separatorIndex + 1),
+  }
+}
+
+export function lookupOmniRouteFallbackModel(
+  cache: Map<string, ModelsDevModel>,
+  modelId: string
+): ModelsDevModel | undefined {
+  let cleanId = modelId.replace(/:[a-zA-Z0-9_-]+$/g, '')
+  const parts = cleanId.split('/')
+  if (parts.length > 2) {
+    cleanId = parts.slice(-2).join('/')
+  }
+
+  const exactMatch = cache.get(cleanId) ?? cache.get(cleanId.toLowerCase())
+  if (exactMatch) return exactMatch
+
+  const requestedModelLower = splitCacheKey(cleanId).model.toLowerCase()
+  const matches: Array<{ provider?: string; value: ModelsDevModel }> = []
+  for (const [key, value] of cache.entries()) {
+    const candidate = splitCacheKey(key)
+    if (candidate.model.toLowerCase() === requestedModelLower) {
+      matches.push({ provider: candidate.provider, value })
+    }
+  }
+
+  if (matches.length === 1) return matches[0]?.value
+
+  for (const preferred of FALLBACK_PROVIDER_PRECEDENCE) {
+    const match = matches.find((candidate) => candidate.provider === preferred)
+    if (match) return match.value
+  }
+
+  return undefined
+}
+
+function createFallbackVariants(
+  info: ModelsDevModel | undefined,
+  outputLimit: number | undefined
+): Record<string, unknown> | undefined {
+  const options = info?.reasoning_options
+  if (!Array.isArray(options) || options.length === 0) return undefined
+
+  const effortValues = options.find((option) => option?.type === 'effort' && Array.isArray(option.values))?.values ?? []
+  const efforts = [...new Set(effortValues.filter((value) => typeof value === 'string' && value.trim().length > 0))]
+  if (efforts.length > 0) {
+    return createEffortVariants(efforts)
+  }
+
+  const budgetOption = options.find((option) => option?.type === 'budget_tokens')
+  if (!budgetOption) return undefined
+
+  const minBudget = hasUsableNumber(budgetOption.min) ? budgetOption.min : 1024
+  const capBudget = (budget: number): number => {
+    const capped = hasUsableNumber(outputLimit) ? Math.min(budget, outputLimit - 1) : budget
+    return Math.max(minBudget, capped)
+  }
+  const highBudget = hasUsableNumber(outputLimit)
+    ? Math.min(HIGH_THINKING_BUDGET, Math.floor(outputLimit / 2 - 1))
+    : HIGH_THINKING_BUDGET
+
+  return {
+    high: { thinking: { type: 'enabled', budgetTokens: capBudget(highBudget) } },
+    max: { thinking: { type: 'enabled', budgetTokens: capBudget(MAX_THINKING_BUDGET) } },
+  }
+}
+
+export function createOmniRouteModelInfoEnricher(data: unknown): ModelInfoEnricher {
+  const cache = data instanceof Map ? data as Map<string, ModelsDevModel> : new Map<string, ModelsDevModel>()
+
+  return {
+    shouldSkipModel(): boolean {
+      return false
+    },
+    getModelName(modelId: string, rawModel?: Record<string, unknown>): string | undefined {
+      const inlineName = rawModel?.name
+      if (typeof inlineName === 'string' && inlineName.length > 0) return inlineName
+
+      return lookupOmniRouteFallbackModel(cache, modelId)?.name
+    },
+    applyModelInfo(modelConfig: any, modelId: string, rawModel?: Record<string, unknown>): void {
+      const capabilities = getCapabilities(rawModel)
+      const fallback = lookupOmniRouteFallbackModel(cache, modelId)
+
+      // Context and output limits: inline OmniRoute fields win, models.dev fills gaps per field.
+      const context = firstUsableNumber(rawModel?.context_length, fallback?.limit?.context)
+      const input = firstUsableNumber(rawModel?.max_input_tokens, fallback?.limit?.input)
+      const output = firstUsableNumber(rawModel?.max_output_tokens, fallback?.limit?.output)
+      if (hasUsableNumber(context)) {
+        modelConfig.limit = {
+          context,
+          ...(hasUsableNumber(input) ? { input } : {}),
+          // OpenCode requires both fields when a limit object is present. Zero preserves its output-token fallback.
+          output: hasUsableNumber(output) ? output : 0,
+        }
+      }
+
+      const inputModalities = getModalities(rawModel?.input_modalities) ?? getModalities(fallback?.modalities?.input)
+      const outputModalities = getModalities(rawModel?.output_modalities) ?? getModalities(fallback?.modalities?.output)
+      if (inputModalities || outputModalities) {
+        modelConfig.modalities = {
+          ...(inputModalities ? { input: inputModalities } : {}),
+          ...(outputModalities ? { output: outputModalities } : {}),
+        }
+      }
+
+      const reasoning = firstBoolean(capabilities?.reasoning, capabilities?.thinking, capabilities?.supportsThinking, fallback?.reasoning)
+      if (reasoning !== undefined) modelConfig.reasoning = reasoning
+      const toolCall = firstBoolean(capabilities?.tool_calling, fallback?.tool_call)
+      if (toolCall !== undefined) modelConfig.tool_call = toolCall
+      const attachment = firstBoolean(capabilities?.attachment, fallback?.attachment)
+      if (attachment !== undefined) modelConfig.attachment = attachment
+      const temperature = firstBoolean(capabilities?.temperature, fallback?.temperature)
+      if (temperature !== undefined) modelConfig.temperature = temperature
+      const structuredOutput = firstBoolean(capabilities?.structured_output, fallback?.structured_output)
+      if (structuredOutput !== undefined) modelConfig.structured_output = structuredOutput
+
+      const cost = createInlineCost(rawModel?.pricing) ?? createFallbackCost(fallback?.cost)
+      if (cost) modelConfig.cost = cost
+
+      const family = rawModel?.family
+      if (typeof family === 'string' && family.length > 0) modelConfig.family = family
+      const releaseDate = rawModel?.release_date
+      if (typeof releaseDate === 'string' && releaseDate.length > 0) modelConfig.release_date = releaseDate
+
+      // Reasoning-effort variants: OmniRoute's advertised effort tiers win.
+      // When the catalog does not serve effort levels, models.dev
+      // reasoning_options keep variants working (effort values or thinking budgets).
+      const effortTiers = getEffortTiers(capabilities)
+      if (effortTiers.length > 0) {
+        modelConfig.variants = createEffortVariants(effortTiers)
+        modelConfig.reasoning = true
+      } else if (modelConfig.reasoning === true) {
+        const fallbackVariants = createFallbackVariants(fallback, hasUsableNumber(output) ? output : undefined)
+        if (fallbackVariants) modelConfig.variants = fallbackVariants
+      }
+    },
+  }
+}

--- a/src/utils/models-dev-fetcher.ts
+++ b/src/utils/models-dev-fetcher.ts
@@ -1,3 +1,9 @@
+export interface ModelsDevReasoningOption {
+  type?: string
+  values?: string[]
+  min?: number
+}
+
 export interface ModelsDevModel {
   id: string
   name?: string
@@ -15,6 +21,13 @@ export interface ModelsDevModel {
     input?: number
     output?: number
   }
+  cost?: {
+    input?: number
+    output?: number
+    cache_read?: number
+    cache_write?: number
+  }
+  reasoning_options?: ModelsDevReasoningOption[]
 }
 
 const MODELS_DEV_URL = 'https://models.dev/models.json'
@@ -55,6 +68,21 @@ function addModel(cache: Map<string, ModelsDevModel>, providerId: string | undef
       input: typeof rawModel.limit.input === 'number' ? rawModel.limit.input : undefined,
       output: typeof rawModel.limit.output === 'number' ? rawModel.limit.output : undefined,
     } : undefined,
+    cost: isObject(rawModel.cost) ? {
+      input: typeof rawModel.cost.input === 'number' ? rawModel.cost.input : undefined,
+      output: typeof rawModel.cost.output === 'number' ? rawModel.cost.output : undefined,
+      cache_read: typeof rawModel.cost.cache_read === 'number' ? rawModel.cost.cache_read : undefined,
+      cache_write: typeof rawModel.cost.cache_write === 'number' ? rawModel.cost.cache_write : undefined,
+    } : undefined,
+    reasoning_options: Array.isArray(rawModel.reasoning_options) ? rawModel.reasoning_options
+      .filter(isObject)
+      .map((option) => ({
+        type: typeof option.type === 'string' ? option.type : undefined,
+        values: Array.isArray(option.values)
+          ? option.values.filter((value: unknown): value is string => typeof value === 'string')
+          : undefined,
+        min: typeof option.min === 'number' ? option.min : undefined,
+      })) : undefined,
   })
 }
 
@@ -89,7 +117,8 @@ export async function fetchModelsDevData(): Promise<Map<string, ModelsDevModel>>
   if (modelsDevCache) return modelsDevCache
 
   try {
-    const response = await fetch(MODELS_DEV_URL, {
+    const modelsDevUrl = process.env.OPENCODE_MODELS_DISCOVERY_MODELS_DEV_URL ?? MODELS_DEV_URL
+    const response = await fetch(modelsDevUrl, {
       method: 'GET',
       signal: AbortSignal.timeout(3000),
     })

--- a/test/omni-route-model-info.test.ts
+++ b/test/omni-route-model-info.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+import { modelsDevTestUtils } from '../src/utils/models-dev-fetcher'
+
+const modelsDevFixture = modelsDevTestUtils.parseModelsDevData({
+  anthropic: {
+    models: {
+      'claude-x': {
+        id: 'claude-x',
+        name: 'Claude X',
+        attachment: true,
+        reasoning: true,
+        tool_call: true,
+        temperature: false,
+        modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+        limit: { context: 1000000, output: 128000 },
+        cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+        reasoning_options: [{ type: 'effort', values: ['low', 'medium', 'high', 'xhigh', 'max'] }],
+      },
+      'claude-compact': {
+        id: 'claude-compact',
+        name: 'Claude Compact',
+        attachment: true,
+        reasoning: true,
+        tool_call: true,
+        temperature: true,
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        limit: { context: 200000, output: 64000 },
+        cost: { input: 1, output: 5 },
+        reasoning_options: [{ type: 'budget_tokens', min: 1024 }],
+      },
+    },
+  },
+  'some-gateway': {
+    models: {
+      'claude-x': {
+        id: 'claude-x',
+        name: 'Claude X (Reseller)',
+        reasoning: true,
+        tool_call: true,
+        limit: { context: 131072, output: 8192 },
+        cost: { input: 99, output: 99 },
+      },
+      'gateway-only-model': {
+        id: 'gateway-only-model',
+        name: 'Gateway Only A',
+        limit: { context: 4096, output: 4096 },
+      },
+    },
+  },
+  'other-gateway': {
+    models: {
+      'gateway-only-model': {
+        id: 'gateway-only-model',
+        name: 'Gateway Only B',
+        limit: { context: 8192, output: 8192 },
+      },
+    },
+  },
+  'vendor-pass': {
+    models: {
+      'vendor-pass/open-model': {
+        id: 'vendor-pass/open-model',
+        name: 'Open Model',
+        attachment: false,
+        reasoning: true,
+        tool_call: true,
+        temperature: true,
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 512000, output: 131072 },
+        cost: { input: 1.4, output: 4.4, cache_read: 0.26 },
+        reasoning_options: [{ type: 'effort', values: ['high', 'max'] }],
+      },
+    },
+  },
+})
+
+function createEnricher() {
+  const enricher = createModelInfoEnricher(ModelInfoFormat.OmniRoute, modelsDevFixture)
+  expect(enricher).toBeDefined()
+  return enricher!
+}
+
+describe('OmniRoute model info enricher', () => {
+  it('extracts inline catalog metadata including effort-tier variants', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'cx/gpt-y' }
+    const rawModel: Record<string, unknown> = {
+      id: 'cx/gpt-y',
+      name: 'cx/GPT Y',
+      family: 'gpt-y',
+      release_date: '2026-07-09',
+      capabilities: {
+        vision: true,
+        tool_calling: true,
+        reasoning: true,
+        thinking: true,
+        effort_tiers: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+        attachment: true,
+        structured_output: true,
+        temperature: false,
+      },
+      input_modalities: ['text', 'image', 'pdf'],
+      output_modalities: ['text'],
+      context_length: 272000,
+      max_input_tokens: 272000,
+      max_output_tokens: 128000,
+      pricing: { input: 5, output: 30, cached: 0.5, cache_creation: 6.25 },
+    }
+
+    expect(enricher.getModelName?.(modelConfig.id, rawModel)).toBe('cx/GPT Y')
+    enricher.applyModelInfo(modelConfig, modelConfig.id, rawModel)
+
+    expect(modelConfig).toMatchObject({
+      limit: { context: 272000, input: 272000, output: 128000 },
+      modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+      reasoning: true,
+      tool_call: true,
+      attachment: true,
+      temperature: false,
+      structured_output: true,
+      family: 'gpt-y',
+      release_date: '2026-07-09',
+      cost: { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+    })
+    expect(modelConfig.variants).toEqual({
+      low: { reasoningEffort: 'low' },
+      medium: { reasoningEffort: 'medium' },
+      high: { reasoningEffort: 'high' },
+      xhigh: { reasoningEffort: 'xhigh' },
+      max: { reasoningEffort: 'max' },
+      ultra: { reasoningEffort: 'ultra' },
+    })
+  })
+
+  it('fills missing fields from models.dev and prefers first-party entries on ambiguity', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'cc/claude-x' }
+    const rawModel: Record<string, unknown> = {
+      id: 'cc/claude-x',
+      capabilities: {
+        reasoning: true,
+        effort_tiers: ['none', 'low', 'medium', 'high', 'xhigh'],
+      },
+      context_length: 500000,
+    }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, rawModel)
+
+    // context from the gateway wins; output, modalities, flags, and cost come
+    // from the first-party anthropic entry, not the reseller entry.
+    expect(modelConfig.limit).toEqual({ context: 500000, output: 128000 })
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image', 'pdf'], output: ['text'] })
+    expect(modelConfig).toMatchObject({
+      reasoning: true,
+      tool_call: true,
+      attachment: true,
+      temperature: false,
+      cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+    })
+    // inline effort tiers still win over models.dev reasoning_options
+    expect(Object.keys(modelConfig.variants)).toEqual(['none', 'low', 'medium', 'high', 'xhigh'])
+  })
+
+  it('falls back to models.dev effort values when the gateway serves no effort tiers', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'cp/vendor-pass/open-model' }
+    const rawModel: Record<string, unknown> = {
+      id: 'cp/vendor-pass/open-model',
+      capabilities: { reasoning: true, tool_calling: true },
+      context_length: 512000,
+      max_output_tokens: 131072,
+    }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, rawModel)
+
+    expect(modelConfig.variants).toEqual({
+      high: { reasoningEffort: 'high' },
+      max: { reasoningEffort: 'max' },
+    })
+    expect(modelConfig.cost).toEqual({ input: 1.4, output: 4.4, cache_read: 0.26 })
+  })
+
+  it('falls back to models.dev thinking budgets when only budget_tokens is available', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'cc/claude-compact' }
+    const rawModel: Record<string, unknown> = {
+      id: 'cc/claude-compact',
+      capabilities: { reasoning: true },
+      context_length: 200000,
+      max_output_tokens: 64000,
+    }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, rawModel)
+
+    expect(modelConfig.variants).toEqual({
+      high: { thinking: { type: 'enabled', budgetTokens: 16000 } },
+      max: { thinking: { type: 'enabled', budgetTokens: 31999 } },
+    })
+  })
+
+  it('does not generate variants for non-reasoning models', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'cp/vendor-pass/open-model' }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, {
+      id: modelConfig.id,
+      capabilities: { reasoning: false, tool_calling: true },
+      context_length: 512000,
+    })
+
+    expect(modelConfig.reasoning).toBe(false)
+    expect(modelConfig.variants).toBeUndefined()
+  })
+
+  it('gives up on ambiguous fallback lookups without a preferred first-party provider', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'xy/gateway-only-model' }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, { id: modelConfig.id })
+
+    expect(modelConfig.limit).toBeUndefined()
+    expect(modelConfig.cost).toBeUndefined()
+    expect(modelConfig.modalities).toBeUndefined()
+  })
+
+  it('leaves missing or malformed metadata unset and preserves zero prices', () => {
+    const enricher = createEnricher()
+    const modelConfig: any = { id: 'unknown/mystery-model' }
+
+    enricher.applyModelInfo(modelConfig, modelConfig.id, {
+      id: modelConfig.id,
+      capabilities: { effort_tiers: [1, '', null] },
+      input_modalities: ['TEXT', 'unsupported', 2],
+      context_length: -5,
+      max_output_tokens: 'many',
+      pricing: { input: 0, output: 0 },
+    })
+
+    expect(modelConfig).toEqual({
+      id: 'unknown/mystery-model',
+      modalities: { input: ['text'] },
+      cost: { input: 0, output: 0 },
+    })
+    expect(modelConfig.limit).toBeUndefined()
+    expect(modelConfig.variants).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Adds modelInfoFormat: "omni-route" for OmniRoute-style gateways whose /v1/models response carries rich inline metadata per model.

Inline metadata mapped to OpenCode model config:
- capabilities flags -> reasoning, tool_call, attachment, temperature, structured_output (reasoning also honors thinking/supportsThinking)
- capabilities.effort_tiers -> one { reasoningEffort } variant per tier, so every advertised thinking level is selectable via variant_cycle
- input_modalities / output_modalities -> modalities (speech -> audio)
- context_length / max_input_tokens / max_output_tokens -> limit
- pricing (USD per 1M: input/output/cached/cache_creation) -> cost
- name / family / release_date passthrough

models.dev per-field fallback (fetched once, as with models.dev format):
- fills context, input, and output limits, modalities, capability flags, and cost only where the gateway entry has gaps
- keeps variants working when effort tiers are not served: reasoning_options effort values map to reasoningEffort variants, and budget_tokens options produce high/max thinking-budget variants mirroring OpenCode's built-in Anthropic-style budgets
- prefixed gateway ids (cc/model, cp/vendor/model) resolve via last-two- segment exact match, then bare-name match with a deterministic first-party provider tie-break; ambiguous lookups give up rather than guessing

Also:
- ModelsDevModel now parses cost and reasoning_options
- OPENCODE_MODELS_DISCOVERY_MODELS_DEV_URL env override for the models.dev index URL (testing / air-gapped setups)
- docs for the new format; 7 new unit tests (107 total pass)
