### PR TITLE
fix: support v1beta model discovery URLs

### DIFF
--- a/src/utils/openai-compatible-api.ts
+++ b/src/utils/openai-compatible-api.ts
@@ -17,11 +17,7 @@ export interface ModelInfoDiscoveryResult {
 }
 
 export function normalizeBaseURL(baseURL: string): string {
-  let normalized = baseURL.replace(/\/+$/, '')
-  if (normalized.endsWith('/v1')) {
-    normalized = normalized.slice(0, -3)
-  }
-  return normalized
+  return baseURL.replace(/\/+$/, '').replace(/\/v1(?:beta)?$/, '')
 }
 
 export function buildAPIURL(baseURL: string, endpoint: string = OPENAI_COMPATIBLE_MODELS_ENDPOINT): string {
@@ -125,7 +121,7 @@ export function isOpenAICompatibleProvider(provider: any): boolean {
 export function hasOpenAICompatibleURL(provider: any): boolean {
   if (!provider || typeof provider !== 'object') return false
   const baseURL = provider.options?.baseURL || ""
-  return /\/v1(\/|$)/.test(baseURL)
+  return /\/v1(?:beta)?(\/|$)/.test(baseURL)
 }
 
 export function hasModelsDiscoveryEndpoint(provider: any): boolean {

--- a/test/openai-compatible-api.test.ts
+++ b/test/openai-compatible-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createServer, type Server } from 'node:http'
-import { discoverModelsFromProvider } from '../src/utils/openai-compatible-api'
+import { canDiscoverModels, discoverModelsFromProvider } from '../src/utils/openai-compatible-api'
 
 describe('OpenAI-compatible API discovery', () => {
   async function withServer(handler: Parameters<typeof createServer>[0], test: (baseURL: string) => Promise<void>): Promise<void> {
@@ -40,6 +40,25 @@ describe('OpenAI-compatible API discovery', () => {
       expect(result.ok).toBe(true)
       expect(result.models.map(model => model.id)).toEqual(['local-model'])
     })
+  })
+
+  it('uses the OpenAI-compatible models endpoint for v1beta base URLs', async () => {
+    await withServer((req, res) => {
+      expect(req.url).toBe('/v1/models')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ data: [] }))
+    }, async (baseURL) => {
+      const result = await discoverModelsFromProvider(`${baseURL}/v1beta`)
+
+      expect(result).toEqual({ ok: true, models: [] })
+    })
+  })
+
+  it('recognizes v1beta providers as OpenAI-compatible discovery targets', () => {
+    expect(canDiscoverModels({
+      npm: '@ai-sdk/google',
+      options: { baseURL: 'https://example.com/v1beta' },
+    })).toBe(true)
   })
 
   it('treats an empty model list as a successful response', async () => {


### PR DESCRIPTION
## Problem

Google-compatible providers can use a `baseURL` ending in `/v1beta` while exposing an OpenAI-compatible model list at `/v1/models`. The current URL normalization only strips `/v1`, producing `/v1beta/v1/models`.

## Change

- Strip either `/v1` or `/v1beta` before appending the discovery endpoint.
- Recognize `/v1beta` base URLs during automatic compatibility detection.
- Cover URL construction and provider detection with tests.

## Verification

- `npm run typecheck`
- `npm run test:run` (119 tests passed)
- `opencode models sub2api-google` against a sub2api provider configured with `baseURL: .../v1beta` and `modelsDiscovery.endpoint: /v1/models` returned all six Gemini models.

Lint is currently blocked by the repository's ESLint setup: ESLint 9 requires a flat config, while the legacy `.eslintrc.json` also references an undeclared `@typescript-eslint/parser` dependency.