### PR TITLE
feat: add llama-swap model metadata enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ For LM Studio 0.4.0+'s native v1 REST inventory endpoint:
 }
 ```
 
+For llama-swap's inline `/v1/models` metadata, without another metadata request:
+
+```json
+{
+  "modelsDiscovery": {
+    "enabled": true,
+    "modelInfoFormat": "llama-swap"
+  }
+}
+```
+
 If metadata cannot be fetched or matched safely, discovery still succeeds and the plugin leaves unknown capability fields unset rather than guessing defaults. See [model metadata enrichment](docs/configuration.md#model-metadata-enrichment) for format-specific behavior and configuration.
 
 ## Upgrade Note

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Each provider can configure discovery behavior through `provider.<name>.options.
 | `provider.<name>.options.modelsDiscovery.endpoint` | `string` | Provider-specific models endpoint path. Defaults to `/v1/models` |
 | `provider.<name>.options.modelsDiscovery.timeoutMs` | positive finite `number` | Per-request timeout for the provider's models and provider-specific metadata endpoints. Defaults to `3000` |
 | `provider.<name>.options.modelsDiscovery.modelInfoEndpoint` | `string` | Override a format-specific metadata endpoint. Defaults to `/v1/model/info` for `"litellm"` and `/api/v1/models` for `"lmstudio"` |
-| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"bifrost"`, `"litellm"`, `"models.dev"`, `"vllm"`, `"lmstudio"`, and `"omniroute"` |
+| `provider.<name>.options.modelsDiscovery.modelInfoFormat` | `string` | Model info response format. Currently supports `"bifrost"`, `"litellm"`, `"models.dev"`, `"vllm"`, `"lmstudio"`, `"llama-swap"`, and `"omniroute"` |
 | `provider.<name>.options.modelsDiscovery.filterNonChat` | `boolean` | When model info is available, skip models whose `model_info.mode` is not `chat`. Defaults to `true` |
 | `provider.<name>.options.modelsDiscovery.models.includeRegex` | `string[]` | Shortcut regex allow-list for discovered model ids only |
 | `provider.<name>.options.modelsDiscovery.models.excludeRegex` | `string[]` | Shortcut regex deny-list for discovered model ids only |
@@ -242,7 +242,7 @@ Community provider examples live in [`docs/config_example/`](config_example/).
 
 The generic OpenAI-compatible `/v1/models` endpoint only guarantees a small model list shape. Extra metadata such as context limits, tool calling, reasoning, image input, or structured output is provider-specific, so metadata enrichment is opt-in.
 
-The plugin currently supports six model info formats:
+The plugin currently supports seven model info formats:
 
 | Format | Source | Requires `modelInfoEndpoint` | Notes |
 |--------|--------|------------------------------|-------|
@@ -251,7 +251,34 @@ The plugin currently supports six model info formats:
 | `"models.dev"` | `https://models.dev/models.json` | No | Uses the public models.dev metadata index |
 | `"vllm"` | Fields in the provider's `/v1/models` response | No | Reads vLLM-style `max_model_len` when present |
 | `"lmstudio"` | LM Studio 0.4.0+ `/api/v1/models` inventory | No | Uses `/api/v1/models` by default; set `modelInfoEndpoint` for another path |
+| `"llama-swap"` | Fields in llama-swap's `/v1/models` response | No | Reads inline context, modalities, and function-calling metadata when present |
 | `"omniroute"` | Fields in OmniRoute's `/v1/models` response | No | Reads OmniRoute inline limits, modalities, and capabilities when present |
+
+### llama-swap Model Info
+
+Use `modelInfoFormat: "llama-swap"` for a [llama-swap](https://github.com/mostlygeek/llama-swap) provider. It reads llama-swap's inline metadata from the same `/v1/models` response and does not make another metadata request.
+
+```json
+{
+  "plugin": ["opencode-models-discovery"],
+  "provider": {
+    "llama-swap": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "llama-swap",
+      "options": {
+        "baseURL": "http://127.0.0.1:8080/v1",
+        "modelsDiscovery": {
+          "enabled": true,
+          "modelInfoFormat": "llama-swap"
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+For each discovered model, the plugin maps `context_length` to `limit.context`, falling back to `meta.n_ctx`. Because llama-swap does not report a distinct output limit, the plugin writes `limit.output: 0` to preserve OpenCode's output-token fallback. Optional `meta.llamaswap.max_input_tokens` and `meta.llamaswap.max_output_tokens` values override the corresponding limits when present. It maps `architecture.input_modalities` and `architecture.output_modalities` to lower-case OpenCode modalities, and maps `capabilities.function_calling` or a `tools` entry in `supported_parameters` to `tool_call`. When `smartModelName: true` is set, a non-empty llama-swap `name` becomes the display name. Missing or malformed metadata is left unset.
 
 ### OmniRoute Model Info
 

--- a/src/plugin/commands.ts
+++ b/src/plugin/commands.ts
@@ -123,6 +123,7 @@ Supported plugin options under provider.<id>.options.modelsDiscovery:
 - modelInfoFormat="litellm": enrich from a LiteLLM-compatible /v1/model/info endpoint; modelInfoEndpoint optionally overrides the path
 - modelInfoFormat="vllm": for vLLM-compatible providers whose raw /v1/models entries include a positive numeric max_model_len; without another request, sets limit.context and limit.output for matching discovered models
 - modelInfoFormat="lmstudio": discover callable models through the normal /v1/models endpoint, then enrich exact model-id matches from LM Studio's /api/v1/models inventory
+- modelInfoFormat="llama-swap": read llama-swap's inline /v1/models context, modalities, and function-calling metadata without another request
 - modelInfoFormat="omniroute": read OmniRoute's documented inline /v1/models limits, modalities, and capabilities without another request
 - filterNonChat: when LiteLLM model info is available, skip non-chat models by default
 - cache.enabled: opt in to a provider-scoped persisted discovery cache of filtered and enriched model configurations; defaults to false
@@ -148,6 +149,7 @@ Recommended defaults:
 - use modelInfoFormat="litellm" for LiteLLM-compatible /v1/model/info; set modelInfoEndpoint only when the provider uses another path
 - use modelInfoFormat="vllm" only when the provider's /v1/models response exposes max_model_len; it is not a standard OpenAI-compatible field, does not require modelInfoEndpoint, and does not infer other capabilities
 - use modelInfoFormat="lmstudio" for LM Studio REST metadata enrichment; set modelInfoEndpoint only when LM Studio uses another inventory path
+- use modelInfoFormat="llama-swap" only for llama-swap /v1/models responses; it is an explicit inline-metadata format and does not make another request
 - use modelInfoFormat="omniroute" only for OmniRoute's documented /v1/models response; it is an explicit inline-metadata format and does not make another request
 - configure caching only when the user requests it; it is disabled by default
 - the persisted discovery cache belongs to this plugin and is not a replacement for opencode.json

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -302,7 +302,7 @@ export async function enhanceConfig(
           provider: providerName,
           count: modelsDevCache.size,
         })
-      } else if (!usingPersistedModels && (modelInfoFormat === ModelInfoFormat.Bifrost || modelInfoFormat === ModelInfoFormat.OmniRoute || modelInfoFormat === ModelInfoFormat.VLLM)) {
+      } else if (!usingPersistedModels && (modelInfoFormat === ModelInfoFormat.Bifrost || modelInfoFormat === ModelInfoFormat.LlamaSwap || modelInfoFormat === ModelInfoFormat.OmniRoute || modelInfoFormat === ModelInfoFormat.VLLM)) {
         modelInfoEnricher = createModelInfoEnricher(modelInfoFormat, null)
       } else if (!usingPersistedModels && modelInfoFormat === ModelInfoFormat.LMStudio) {
         const modelInfoEndpoint = providerDiscoveryConfig.modelInfoEndpoint ?? DEFAULT_LMSTUDIO_MODELS_ENDPOINT

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -35,6 +35,7 @@ export enum ModelInfoFormat {
   ModelsDev = 'models.dev',
   VLLM = 'vllm',
   LMStudio = 'lmstudio',
+  LlamaSwap = 'llama-swap',
   OmniRoute = 'omniroute',
 }
 

--- a/src/utils/model-info/index.ts
+++ b/src/utils/model-info/index.ts
@@ -1,6 +1,7 @@
 import { createBifrostModelInfoEnricher } from './bifrost'
 import { createLiteLLMModelInfoEnricher } from './litellm'
 import { createLMStudioModelInfoEnricher } from './lmstudio'
+import { createLlamaSwapModelInfoEnricher } from './llamaswap'
 import { createModelsDevModelInfoEnricher } from './models-dev'
 import { createOmniRouteModelInfoEnricher } from './omniroute'
 import { createVLLMModelInfoEnricher } from './vllm'
@@ -15,6 +16,7 @@ const MODEL_INFO_ENRICHERS: Partial<Record<ModelInfoFormat, ModelInfoEnricherFac
   [ModelInfoFormat.ModelsDev]: createModelsDevModelInfoEnricher,
   [ModelInfoFormat.VLLM]: createVLLMModelInfoEnricher,
   [ModelInfoFormat.LMStudio]: createLMStudioModelInfoEnricher,
+  [ModelInfoFormat.LlamaSwap]: createLlamaSwapModelInfoEnricher,
   [ModelInfoFormat.OmniRoute]: createOmniRouteModelInfoEnricher,
 }
 

--- a/src/utils/model-info/llamaswap.ts
+++ b/src/utils/model-info/llamaswap.ts
@@ -1,0 +1,82 @@
+import type { ModelInfoEnricher } from './types'
+
+function hasUsableNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function hasNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function getModalities(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const supportedModalities = new Set(['text', 'audio', 'image', 'video', 'pdf'])
+  const modalities = [...new Set(value
+    .filter((modality): modality is string => typeof modality === 'string')
+    .map((modality) => modality.trim().toLowerCase())
+    .filter((modality) => supportedModalities.has(modality)))]
+  return modalities.length > 0 ? modalities : undefined
+}
+
+function getLlamaSwapMetadata(rawModel: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return getRecord(getRecord(rawModel?.meta)?.llamaswap)
+}
+
+export function createLlamaSwapModelInfoEnricher(_data: unknown): ModelInfoEnricher {
+  return {
+    shouldSkipModel(): boolean {
+      return false
+    },
+    getModelName(_modelId: string, rawModel?: Record<string, unknown>): string | undefined {
+      const name = rawModel?.name
+      return typeof name === 'string' && name.trim().length > 0 ? name.trim() : undefined
+    },
+    applyModelInfo(modelConfig: any, _modelId: string, rawModel?: Record<string, unknown>): void {
+      const meta = getRecord(rawModel?.meta)
+      const llamaSwapMetadata = getLlamaSwapMetadata(rawModel)
+      const context = hasUsableNumber(rawModel?.context_length)
+        ? rawModel.context_length
+        : hasUsableNumber(meta?.n_ctx) ? meta.n_ctx : undefined
+      if (context) {
+        const input = hasUsableNumber(llamaSwapMetadata?.max_input_tokens)
+          ? llamaSwapMetadata.max_input_tokens
+          : undefined
+        const output = hasNonNegativeNumber(llamaSwapMetadata?.max_output_tokens)
+          ? llamaSwapMetadata.max_output_tokens
+          : 0
+        modelConfig.limit = {
+          context,
+          ...(input ? { input } : {}),
+          output,
+        }
+      }
+
+      const architecture = getRecord(rawModel?.architecture)
+      const inputModalities = getModalities(architecture?.input_modalities)
+      const outputModalities = getModalities(architecture?.output_modalities)
+      if (inputModalities || outputModalities) {
+        modelConfig.modalities = {
+          ...(inputModalities ? { input: inputModalities } : {}),
+          ...(outputModalities ? { output: outputModalities } : {}),
+          ...(!inputModalities && modelConfig.modalities?.input ? { input: modelConfig.modalities.input } : {}),
+          ...(!outputModalities && modelConfig.modalities?.output ? { output: modelConfig.modalities.output } : {}),
+        }
+      }
+
+      const capabilities = getRecord(rawModel?.capabilities)
+      const supportedParameters = Array.isArray(rawModel?.supported_parameters)
+        ? rawModel.supported_parameters
+        : []
+      if (capabilities?.function_calling === true || supportedParameters.includes('tools')) {
+        modelConfig.tool_call = true
+      }
+    },
+  }
+}

--- a/test/llamaswap-model-info.test.ts
+++ b/test/llamaswap-model-info.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+
+describe('llama-swap model info enricher', () => {
+  it('maps inline context, modalities, display name, and function calling', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LlamaSwap, null)
+    expect(enricher).toBeDefined()
+
+    const config: any = {
+      id: 'Gemma-4-31B-It',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+    const rawModel: Record<string, unknown> = {
+      id: config.id,
+      name: 'Gemma 4 31B IT',
+      context_length: 9216,
+      architecture: {
+        input_modalities: ['text', 'image'],
+        output_modalities: ['text'],
+      },
+      capabilities: { function_calling: true, vision: true },
+      supported_parameters: ['tools', 'tool_choice'],
+      meta: {
+        n_ctx: 9216,
+        llamaswap: { type: 'model' },
+      },
+    }
+
+    expect(enricher!.getModelName?.(config.id, rawModel)).toBe('Gemma 4 31B IT')
+    enricher!.applyModelInfo(config, config.id, rawModel)
+
+    expect(config).toMatchObject({
+      limit: { context: 9216, output: 0 },
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      tool_call: true,
+    })
+  })
+
+  it('falls back to meta.n_ctx and honors optional configured input and output limits', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LlamaSwap, null)
+    const config: any = { id: 'local-model' }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      meta: {
+        n_ctx: 34816,
+        llamaswap: {
+          max_input_tokens: 32768,
+          max_output_tokens: 2048,
+        },
+      },
+    })
+
+    expect(config.limit).toEqual({ context: 34816, input: 32768, output: 2048 })
+  })
+
+  it('uses supported_parameters as a tool-calling fallback', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LlamaSwap, null)
+    const config: any = { id: 'tool-model' }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      supported_parameters: ['tools'],
+    })
+
+    expect(config.tool_call).toBe(true)
+  })
+
+  it('leaves malformed metadata unset and preserves default modalities', () => {
+    const enricher = createModelInfoEnricher(ModelInfoFormat.LlamaSwap, null)
+    const config: any = {
+      id: 'invalid-model',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    enricher!.applyModelInfo(config, config.id, {
+      id: config.id,
+      name: '   ',
+      context_length: '32768',
+      architecture: {
+        input_modalities: ['unsupported', 1],
+        output_modalities: [],
+      },
+      capabilities: 'invalid',
+      supported_parameters: 'tools',
+      meta: { n_ctx: -1 },
+    })
+
+    expect(enricher!.getModelName?.(config.id, { name: '   ' })).toBeUndefined()
+    expect(config).toEqual({
+      id: 'invalid-model',
+      modalities: { input: ['text'], output: ['text'] },
+    })
+  })
+})

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -13,6 +13,7 @@ describe('JSON config struct parsing', () => {
     { json: '{"modelInfoFormat":"litellm"}', expected: true },
     { json: '{"modelInfoFormat":"models.dev"}', expected: true },
     { json: '{"modelInfoFormat":"vllm"}', expected: true },
+    { json: '{"modelInfoFormat":"llama-swap"}', expected: true },
     { json: '{"modelInfoFormat":"omniroute"}', expected: true },
     { json: '{"modelInfoFormat":"bogus"}', expected: false },
   ])('handles modelInfoFormat=$json', ({ json, expected }) => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -271,6 +271,7 @@ describe('ModelDiscovery Plugin', () => {
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="litellm"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="vllm"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="lmstudio"')
+        expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="llama-swap"')
         expect(config.command['models-discovery:config'].template).toContain('modelInfoFormat="omniroute"')
         expect(config.command['models-discovery:config'].template).toContain('max_model_len')
         expect(config.command['models-discovery:config'].template).toContain('restart opencode')
@@ -720,6 +721,50 @@ describe('ModelDiscovery Plugin', () => {
         limit: { context: 200000, input: 200000, output: 8192 },
         modalities: { input: ['text', 'image', 'audio'], output: ['text'] },
         cost: { input: 3, output: 15 },
+      })
+    })
+
+    it('enriches llama-swap inline metadata without another request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{
+            id: 'Gemma-4-31B-It',
+            object: 'model',
+            created: 0,
+            owned_by: 'llama-swap',
+            name: 'Gemma 4 31B IT',
+            context_length: 9216,
+            architecture: { input_modalities: ['text', 'image'], output_modalities: ['text'] },
+            capabilities: { function_calling: true, vision: true },
+            supported_parameters: ['tools', 'tool_choice'],
+            meta: { n_ctx: 9216, llamaswap: { type: 'model' } },
+          }],
+        }),
+      })
+
+      const config: any = {
+        provider: {
+          llamaswap: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'http://127.0.0.1:8080/v1',
+              modelsDiscovery: { modelInfoFormat: 'llama-swap', smartModelName: true },
+            },
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(config.provider.llamaswap.models['Gemma-4-31B-It']).toMatchObject({
+        id: 'Gemma-4-31B-It',
+        name: 'Gemma 4 31B IT',
+        limit: { context: 9216, output: 0 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        tool_call: true,
       })
     })
 


### PR DESCRIPTION
## Summary

- Add `modelInfoFormat: "llama-swap"` ([github.com/mostlygeek/llama-swap](https://github.com/mostlygeek/llama-swap)) to enrich discovered models from inline `/v1/models` metadata.
- Map context limits, modalities, display names, and tool-use support into OpenCode model configuration without an additional request.

## Validation

- `npm run typecheck`
- Relevant unit and integration tests
- Tested against a live llama-swap response

Note: LLMs were heavily used here, but the feature is simple enough. llama-swap config must actually have the metadata filled in in the config, it's doesn't auto-populate it.