### PR TITLE
feat: map OmniRoute effort tiers to variants

### DIFF
--- a/src/utils/model-info/omniroute.ts
+++ b/src/utils/model-info/omniroute.ts
@@ -23,6 +23,29 @@ function getCapabilities(rawModel: Record<string, unknown> | undefined): Record<
     : undefined
 }
 
+function getReasoningVariants(capabilities: Record<string, unknown> | undefined): Record<string, { reasoningEffort: string }> | undefined {
+  if (capabilities?.reasoning !== true || !Array.isArray(capabilities.effort_tiers)) return undefined
+
+  const supportedTiers: Record<string, true> = {
+    none: true,
+    minimal: true,
+    low: true,
+    medium: true,
+    high: true,
+    xhigh: true,
+    max: true,
+    ultra: true,
+  }
+  const variants = Object.fromEntries(
+    capabilities.effort_tiers
+      .filter((tier): tier is string => typeof tier === 'string')
+      .map(tier => tier.trim().toLowerCase())
+      .filter(tier => supportedTiers[tier] === true)
+      .map(tier => [tier, { reasoningEffort: tier }])
+  )
+  return Object.keys(variants).length > 0 ? variants : undefined
+}
+
 export function createOmniRouteModelInfoEnricher(_data: unknown): ModelInfoEnricher {
   return {
     shouldSkipModel(): boolean {
@@ -58,6 +81,9 @@ export function createOmniRouteModelInfoEnricher(_data: unknown): ModelInfoEnric
       if (typeof capabilities?.tool_calling === 'boolean') modelConfig.tool_call = capabilities.tool_calling
       if (typeof capabilities?.structured_output === 'boolean') modelConfig.structured_output = capabilities.structured_output
       if (typeof capabilities?.temperature === 'boolean') modelConfig.temperature = capabilities.temperature
+
+      const variants = getReasoningVariants(capabilities)
+      if (variants) modelConfig.variants = variants
     },
   }
 }

--- a/test/omniroute-model-info.test.ts
+++ b/test/omniroute-model-info.test.ts
@@ -24,6 +24,7 @@ describe('OmniRoute model info enricher', () => {
         structured_output: true,
         temperature: false,
         vision: true,
+        effort_tiers: ['LOW', 'medium', 'high', 'xhigh', 'ultra'],
       },
     })
 
@@ -35,6 +36,13 @@ describe('OmniRoute model info enricher', () => {
       tool_call: true,
       structured_output: true,
       temperature: false,
+      variants: {
+        low: { reasoningEffort: 'low' },
+        medium: { reasoningEffort: 'medium' },
+        high: { reasoningEffort: 'high' },
+        xhigh: { reasoningEffort: 'xhigh' },
+        ultra: { reasoningEffort: 'ultra' },
+      },
     })
   })
 


### PR DESCRIPTION
## Summary

Expose OmniRoute reasoning-effort tiers as OpenCode model variants.

Closes #74.

## Problem

The OmniRoute model-info enricher maps `capabilities.reasoning`, but ignores `capabilities.effort_tiers`. OpenCode consequently sees that a model supports reasoning without receiving the variants required by its reasoning-level selector.

## Changes

- Read `capabilities.effort_tiers` when reasoning is enabled.
- Normalize tier names before generating variants.
- Map recognized tiers to `{ reasoningEffort: tier }`.
- Ignore malformed and unsupported values.
- Extend the existing OmniRoute model-info test with variant assertions.

Supported tier names:

- `none`
- `minimal`
- `low`
- `medium`
- `high`
- `xhigh`
- `max`
- `ultra`

## Result

For metadata such as:

```json
{
  "capabilities": {
    "reasoning": true,
    "effort_tiers": ["low", "medium", "high", "xhigh", "ultra"]
  }
}
```

the enricher now generates:

```json
{
  "variants": {
    "low": { "reasoningEffort": "low" },
    "medium": { "reasoningEffort": "medium" },
    "high": { "reasoningEffort": "high" },
    "xhigh": { "reasoningEffort": "xhigh" },
    "ultra": { "reasoningEffort": "ultra" }
  }
}
```

## Verification

```text
npm run typecheck
npm run test:run -- test/omniroute-model-info.test.ts
```

The targeted test suite passes: 1 test file, 3 tests.
