### PR TITLE
feat(discovery): map inline OpenAI-compatible model metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,11 @@ The migration assistant is instructed to inspect project config, user global con
 
 ## Model Metadata Enrichment
 
-Discovery adds model ids to your OpenCode provider config. Some providers only expose minimal `/models` responses, so the plugin can optionally enrich discovered models with OpenCode-compatible capability metadata such as context limits, output limits, reasoning, tool calling, attachments, structured output, temperature support, and modalities.
+Discovery adds model ids to your OpenCode provider config and maps recognized inline metadata into OpenCode-compatible model fields such as context limits, output limits, reasoning, tool calling, attachments, structured output, temperature support, and modalities.
 
-Metadata enrichment is explicit. The plugin does not contact external metadata sources unless configured.
+The plugin always maps recognized metadata present in the provider's `/v1/models` response. This includes OpenCode-shaped `limit`, standard context fields such as `context_length`, `max_context_length`, and `max_input_tokens`, `max_output_tokens`, `modalities`/`input_modalities`/`output_modalities`, capability flags, `cost`, `family`, `release_date`, and `interleaved`. Unknown fields are ignored. `smartModelName: true` also uses a provider `name`, `display_name`, or `normalized_name` when available.
+
+The generic mapping does not guess pricing units from a provider-specific `pricing` object. Configure one of the explicit metadata formats below when a provider documents a pricing or capability schema that needs additional interpretation. The plugin does not contact external metadata sources unless configured.
 
 For models.dev enrichment:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,7 +242,16 @@ Community provider examples live in [`docs/config_example/`](config_example/).
 
 ## Model Metadata Enrichment
 
-The generic OpenAI-compatible `/v1/models` endpoint only guarantees a small model list shape. Extra metadata such as context limits, tool calling, reasoning, image input, or structured output is provider-specific, so metadata enrichment is opt-in.
+The plugin always maps recognized metadata present in a provider's OpenAI-compatible `/v1/models` response. This lets providers such as Carcará expose context and output limits without a second metadata request.
+
+Recognized inline fields include:
+
+- limits: `limit.context/input/output`, `context_length`, `max_context_length`, `native_context_length`, `max_model_len`, `max_input_tokens`, and `max_output_tokens` (plus common aliases);
+- modalities: `modalities`, `input_modalities`, `output_modalities`, and `architecture` modality fields;
+- capabilities: attachment, reasoning, tools/function calling, structured output, temperature, supported parameters, and interleaved reasoning;
+- model metadata: `cost`, `family`, and `release_date`.
+
+The plugin ignores unknown fields and does not infer pricing units from a provider-specific `pricing` object. Explicit `modelInfoFormat` enrichment remains opt-in for provider-specific endpoints and schemas.
 
 The plugin currently supports seven model info formats:
 

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -7,6 +7,7 @@ import { normalizeProviderOriginForCache, discoverModelsFromProvider, discoverMo
 import { createModelInfoEnricher, isSupportedModelInfoFormat, type ModelInfoEnricher } from '../utils/model-info'
 import { DEFAULT_CACHE_TTL_SECONDS, getDefaultDiscoveryConfigFromEnv, getProviderModelFieldFilters, getProviderModelRegexFilter, shouldDiscoverModel, shouldDiscoverModelByFields, shouldDiscoverProviderWithOverride, ModelInfoFormat } from '../types/plugin-config'
 import { DEFAULT_MODELS_DEV_URL, fetchModelsDevData } from '../utils/models-dev-fetcher'
+import { applyOpenAIModelMetadata, getOpenAIModelDisplayName } from '../utils/openai-model-metadata'
 import { isInventoryFresh, mergeModelOverride, ProviderModelStore, type ProviderModelState } from './provider-model-store'
 import type { PluginLogger } from './logger'
 import type { PluginInput } from '@opencode-ai/plugin'
@@ -365,7 +366,9 @@ export async function enhanceConfig(
           const owner = extractModelOwner(model.id)
           const modelConfig: any = {
             id: model.id,
-            name: smartModelNameEnabled ? modelInfoEnricher?.getModelName?.(model.id, model) ?? formatModelName(model) : model.id,
+            name: smartModelNameEnabled
+              ? modelInfoEnricher?.getModelName?.(model.id, model) ?? getOpenAIModelDisplayName(model) ?? formatModelName(model)
+              : model.id,
           }
 
           if (owner) {
@@ -380,6 +383,7 @@ export async function enhanceConfig(
             }
           }
 
+          applyOpenAIModelMetadata(modelConfig, model)
           modelInfoEnricher?.applyModelInfo(modelConfig, model.id, model)
           discoveredModels[modelKey] = modelConfig
         }

--- a/src/utils/openai-model-metadata.ts
+++ b/src/utils/openai-model-metadata.ts
@@ -1,0 +1,286 @@
+type ModelRecord = Record<string, unknown>
+
+const SUPPORTED_MODALITIES = new Set(['text', 'audio', 'image', 'video', 'pdf'])
+const MODALITY_ALIASES: Record<string, string> = {
+  image_url: 'image',
+  images: 'image',
+  speech: 'audio',
+  audio_input: 'audio',
+  audio_output: 'audio',
+}
+
+function isRecord(value: unknown): value is ModelRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function toFiniteNumber(value: unknown, minimum: number): number | undefined {
+  const number = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim() !== ''
+      ? Number(value)
+      : undefined
+
+  return number !== undefined && Number.isFinite(number) && number >= minimum ? number : undefined
+}
+
+function toTokenLimit(value: unknown): number | undefined {
+  const number = toFiniteNumber(value, 1)
+  return number !== undefined && Number.isInteger(number) ? number : undefined
+}
+
+function firstTokenLimit(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const number = toTokenLimit(value)
+    if (number !== undefined) return number
+  }
+
+  return undefined
+}
+
+function firstNonNegativeNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const number = toFiniteNumber(value, 0)
+    if (number !== undefined) return number
+  }
+
+  return undefined
+}
+
+function firstBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === 'boolean') return value
+  }
+
+  return undefined
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+function getStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const modalities = [...new Set(value
+    .map(getString)
+    .filter((modality): modality is string => modality !== undefined)
+    .map((modality) => MODALITY_ALIASES[modality.toLowerCase()] ?? modality.toLowerCase())
+    .filter((modality) => SUPPORTED_MODALITIES.has(modality)))]
+
+  return modalities.length > 0 ? modalities : undefined
+}
+
+function firstStringArray(...values: unknown[]): string[] | undefined {
+  for (const value of values) {
+    const modalities = getStringArray(value)
+    if (modalities) return modalities
+  }
+
+  return undefined
+}
+
+function getModalities(rawModel: ModelRecord): { input?: string[]; output?: string[] } {
+  const declared = isRecord(rawModel.modalities) ? rawModel.modalities : undefined
+  const architecture = isRecord(rawModel.architecture) ? rawModel.architecture : undefined
+
+  const input = firstStringArray(
+    declared?.input,
+    rawModel.input_modalities,
+    architecture?.input_modalities,
+  )
+  const output = firstStringArray(
+    declared?.output,
+    rawModel.output_modalities,
+    architecture?.output_modalities,
+  )
+
+  return { input, output }
+}
+
+function getCapabilities(rawModel: ModelRecord): ModelRecord | undefined {
+  return isRecord(rawModel.capabilities) ? rawModel.capabilities : undefined
+}
+
+function getSupportedParameters(rawModel: ModelRecord, capabilities?: ModelRecord): string[] {
+  const values = [
+    rawModel.supported_parameters,
+    rawModel.supported_openai_params,
+    capabilities?.supported_parameters,
+    capabilities?.supported_openai_params,
+  ].flatMap((value) => Array.isArray(value) ? value : [])
+
+  return values
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.toLowerCase())
+}
+
+function supportsParameter(parameters: string[], ...names: string[]): boolean {
+  return names.some((name) => parameters.includes(name))
+}
+
+function applyLimit(modelConfig: ModelRecord, rawModel: ModelRecord): void {
+  const rawLimit = isRecord(rawModel.limit) ? rawModel.limit : undefined
+  const meta = isRecord(rawModel.meta) ? rawModel.meta : undefined
+  const currentLimit = isRecord(modelConfig.limit) ? modelConfig.limit : undefined
+
+  // Prefer an explicit OpenCode-shaped limit, then common local/OpenAI-compatible
+  // names. `max_input_tokens` is the final context fallback used by Carcará.
+  const context = firstTokenLimit(
+    rawLimit?.context,
+    rawModel.context_length,
+    rawModel.max_context_length,
+    rawModel.native_context_length,
+    rawModel.max_model_len,
+    meta?.context_length,
+    meta?.n_ctx,
+    rawModel.max_input_tokens,
+  )
+  const input = firstTokenLimit(
+    rawLimit?.input,
+    rawModel.max_input_tokens,
+    rawModel.max_input_length,
+    rawModel.input_token_limit,
+  )
+  const output = firstTokenLimit(
+    rawLimit?.output,
+    rawModel.max_output_tokens,
+    rawModel.max_output_length,
+    rawModel.max_tokens,
+  )
+
+  if (context === undefined && input === undefined && output === undefined && currentLimit === undefined) {
+    return
+  }
+
+  modelConfig.limit = {
+    ...(currentLimit ?? {}),
+    context: context ?? currentLimit?.context ?? 0,
+    ...(input !== undefined ? { input } : {}),
+    output: output ?? currentLimit?.output ?? 0,
+  }
+}
+
+function mergeModalities(modelConfig: ModelRecord, input?: string[], output?: string[]): void {
+  if (!input && !output) return
+
+  const current = isRecord(modelConfig.modalities) ? modelConfig.modalities : {}
+  modelConfig.modalities = {
+    ...current,
+    ...(input ? { input } : {}),
+    ...(output ? { output } : {}),
+  }
+}
+
+function addInferredInputModalities(modelConfig: ModelRecord, rawModel: ModelRecord, capabilities?: ModelRecord): void {
+  const current = isRecord(modelConfig.modalities) ? modelConfig.modalities : {}
+  const input = getStringArray(current.input) ?? []
+  const inferred = [...input]
+
+  const booleanModalities: Array<[string, string[]]> = [
+    ['image', ['vision', 'supports_vision', 'image']],
+    ['audio', ['audio', 'supports_audio']],
+    ['video', ['video', 'supports_video']],
+    ['pdf', ['pdf', 'supports_pdf']],
+  ]
+
+  for (const [modality, names] of booleanModalities) {
+    const values = names.flatMap((name) => [rawModel[name], capabilities?.[name]])
+    if (firstBoolean(...values) === true && !inferred.includes(modality)) {
+      inferred.push(modality)
+    }
+  }
+
+  if (inferred.length > input.length) {
+    modelConfig.modalities = { ...current, input: inferred }
+  }
+}
+
+function applyCapabilities(modelConfig: ModelRecord, rawModel: ModelRecord, capabilities?: ModelRecord): void {
+  const parameters = getSupportedParameters(rawModel, capabilities)
+  const capability = (...names: string[]): boolean | undefined => firstBoolean(
+    ...names.flatMap((name) => [rawModel[name], capabilities?.[name]]),
+  )
+
+  const attachment = capability('attachment', 'attachments', 'supports_attachment', 'supports_attachments')
+  const reasoning = capability('reasoning', 'supports_reasoning', 'supports_reasoning_effort')
+  const toolCall = capability(
+    'tool_call',
+    'tools',
+    'tool_calling',
+    'function_calling',
+    'supports_tools',
+    'supports_tool_calling',
+    'supports_function_calling',
+  )
+  const structuredOutput = capability(
+    'structured_output',
+    'structured_outputs',
+    'supports_structured_output',
+    'supports_structured_outputs',
+  )
+  const temperature = capability('temperature', 'supports_temperature')
+
+  if (attachment !== undefined) modelConfig.attachment = attachment
+  if (reasoning !== undefined || supportsParameter(parameters, 'reasoning', 'reasoning_effort')) {
+    modelConfig.reasoning = reasoning ?? true
+  }
+  if (toolCall !== undefined || supportsParameter(parameters, 'tools', 'tool_choice', 'functions', 'function_call')) {
+    modelConfig.tool_call = toolCall ?? true
+  }
+  if (structuredOutput !== undefined || supportsParameter(parameters, 'response_format', 'structured_output', 'structured_outputs')) {
+    modelConfig.structured_output = structuredOutput ?? true
+  }
+  if (temperature !== undefined) modelConfig.temperature = temperature
+
+  const interleaved = rawModel.interleaved
+  if (interleaved === true || (isRecord(interleaved) && (interleaved.field === 'reasoning_content' || interleaved.field === 'reasoning_details'))) {
+    modelConfig.interleaved = interleaved
+  }
+}
+
+function applyCost(modelConfig: ModelRecord, rawModel: ModelRecord): void {
+  const rawCost = isRecord(rawModel.cost) ? rawModel.cost : undefined
+  if (!rawCost) return
+
+  const currentCost = isRecord(modelConfig.cost) ? modelConfig.cost : {}
+  const cache = isRecord(rawCost.cache) ? rawCost.cache : undefined
+  const input = firstNonNegativeNumber(rawCost.input)
+  const output = firstNonNegativeNumber(rawCost.output)
+  const cacheRead = firstNonNegativeNumber(rawCost.cache_read, cache?.read)
+  const cacheWrite = firstNonNegativeNumber(rawCost.cache_write, cache?.write)
+
+  if (input === undefined && output === undefined && cacheRead === undefined && cacheWrite === undefined) return
+
+  modelConfig.cost = {
+    ...currentCost,
+    ...(input !== undefined ? { input } : {}),
+    ...(output !== undefined ? { output } : {}),
+    ...(cacheRead !== undefined ? { cache_read: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_write: cacheWrite } : {}),
+  }
+}
+
+export function getOpenAIModelDisplayName(rawModel: ModelRecord): string | undefined {
+  return getString(rawModel.name)
+    ?? getString(rawModel.display_name)
+    ?? getString(rawModel.displayName)
+    ?? getString(rawModel.normalized_name)
+}
+
+export function applyOpenAIModelMetadata(modelConfig: ModelRecord, rawModel: ModelRecord): void {
+  applyLimit(modelConfig, rawModel)
+
+  const declaredModalities = getModalities(rawModel)
+  mergeModalities(modelConfig, declaredModalities.input, declaredModalities.output)
+
+  const capabilities = getCapabilities(rawModel)
+  addInferredInputModalities(modelConfig, rawModel, capabilities)
+  applyCapabilities(modelConfig, rawModel, capabilities)
+  applyCost(modelConfig, rawModel)
+
+  const family = getString(rawModel.family)
+  if (family) modelConfig.family = family
+
+  const releaseDate = getString(rawModel.release_date)
+  if (releaseDate) modelConfig.release_date = releaseDate
+}

--- a/test/openai-model-metadata.test.ts
+++ b/test/openai-model-metadata.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { applyOpenAIModelMetadata, getOpenAIModelDisplayName } from '../src/utils/openai-model-metadata.ts'
+
+describe('OpenAI-compatible model metadata', () => {
+  it('maps Carcará context and output fields into OpenCode limits', () => {
+    const modelConfig: Record<string, unknown> = {
+      id: 'carcara-coder',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    applyOpenAIModelMetadata(modelConfig, {
+      id: 'carcara-coder',
+      context_length: 1_048_576,
+      max_input_tokens: 1_048_576,
+      max_output_tokens: 4096,
+    })
+
+    expect(modelConfig.limit).toEqual({
+      context: 1_048_576,
+      input: 1_048_576,
+      output: 4096,
+    })
+  })
+
+  it('maps standard capabilities, modalities, cost, and interleaved metadata', () => {
+    const modelConfig: Record<string, unknown> = {
+      id: 'rich-model',
+      modalities: { input: ['text'], output: ['text'] },
+    }
+
+    applyOpenAIModelMetadata(modelConfig, {
+      id: 'rich-model',
+      context_length: 128_000,
+      max_output_tokens: 8192,
+      input_modalities: ['TEXT', 'IMAGE'],
+      output_modalities: ['TEXT'],
+      capabilities: {
+        attachment: true,
+        reasoning: true,
+        tools: true,
+        structured_output: true,
+        temperature: false,
+      },
+      cost: { input: 3, output: 15, cache_read: 1, cache_write: 2 },
+      interleaved: { field: 'reasoning_content' },
+      family: 'qwen',
+      release_date: '2026-01-01',
+      supported_openai_params: ['response_format'],
+    })
+
+    expect(modelConfig).toMatchObject({
+      limit: { context: 128_000, output: 8192 },
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      structured_output: true,
+      temperature: false,
+      interleaved: { field: 'reasoning_content' },
+      cost: { input: 3, output: 15, cache_read: 1, cache_write: 2 },
+      family: 'qwen',
+      release_date: '2026-01-01',
+    })
+  })
+
+  it('prefers OpenCode limit values and ignores invalid token metadata', () => {
+    const modelConfig: Record<string, unknown> = { id: 'model' }
+
+    applyOpenAIModelMetadata(modelConfig, {
+      id: 'model',
+      limit: { context: 65_536, input: 60_000, output: 4096 },
+      context_length: 128_000,
+      max_input_tokens: 'not-a-number',
+      max_output_tokens: 4096.5,
+    })
+
+    expect(modelConfig.limit).toEqual({ context: 65_536, input: 60_000, output: 4096 })
+  })
+
+  it('uses provider display names only when the caller opts into smart names', () => {
+    expect(getOpenAIModelDisplayName({ id: 'model', name: 'Friendly model' })).toBe('Friendly model')
+    expect(getOpenAIModelDisplayName({ id: 'model', display_name: 'Friendly model' })).toBe('Friendly model')
+    expect(getOpenAIModelDisplayName({ id: 'model' })).toBeUndefined()
+  })
+})

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -504,6 +504,48 @@ describe('ModelDiscovery Plugin', () => {
       }))
     })
 
+    it('maps inline OpenAI-compatible metadata into discovered model limits', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{
+            id: 'carcara-coder',
+            object: 'model',
+            name: 'Carcará Coder',
+            context_length: 1_048_576,
+            max_input_tokens: 1_048_576,
+            max_output_tokens: 4096,
+            input_modalities: ['text'],
+            output_modalities: ['text'],
+            capabilities: { tool_calling: true },
+          }],
+        }),
+      })
+
+      const config: any = {
+        provider: {
+          carcara: {
+            npm: '@ai-sdk/openai-compatible',
+            options: {
+              baseURL: 'https://carcara.example/v1',
+              modelsDiscovery: { smartModelName: true },
+            },
+            models: {},
+          },
+        },
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.carcara.models['carcara-coder']).toMatchObject({
+        id: 'carcara-coder',
+        name: 'Carcará Coder',
+        limit: { context: 1_048_576, input: 1_048_576, output: 4096 },
+        modalities: { input: ['text'], output: ['text'] },
+        tool_call: true,
+      })
+    })
+
     it('uses a fresh persisted inventory without resolving credentials or requesting models', async () => {
       const store = new ProviderModelStore(cacheRoot)
       await store.saveModels({


### PR DESCRIPTION
## Summary

Resolve recognized metadata returned inline by OpenAI-compatible `/v1/models` responses into OpenCode model configuration. This lets providers such as Carcará advertise limits and capabilities without a separate metadata endpoint or static client model map.

## Changes

- Map context, input, and output limits from standard fields and common aliases.
- Map modalities, capability flags, supported parameters, costs, family, release date, and display names.
- Keep generic mapping before provider-specific enrichers and explicit configuration overrides.
- Ignore unknown fields and avoid guessing units for provider-specific pricing fields.
- Add unit and plugin integration coverage plus documentation.

## Testing

- `bun test test/openai-model-metadata.test.ts` (4 tests passed)
- Bun builds passed for the helper and changed plugin/test sources with unavailable dependencies marked external.
- `git diff --check`

The full plugin test suite could not run because this clone has no installed dependencies (`xdg-basedir`, Vitest, and the OpenCode plugin package). No dependencies were installed.