### PR TITLE
fix(litellm): honor model_info modalities and per-tier reasoning-effort flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,7 +368,7 @@ Set `modelInfoFormat` to `"litellm"` to enable it. The plugin requests `/v1/mode
 When model info is available, the plugin uses LiteLLM `model_info` fields to populate OpenCode model configuration:
 
 - `max_input_tokens`, `max_output_tokens`, and `max_tokens` become `limit.context`, `limit.input`, and `limit.output`
-- `modalities.input` and `modalities.output` become `modalities`, normalized to lowercase (`speech` becomes `audio`) and limited to `text`, `audio`, `image`, `video`, and `pdf`; the undeclared side defaults to `["text"]`
+- `modalities.input` and `modalities.output` become `modalities`, normalized to lowercase (`speech` becomes `audio`) and limited to `text`, `audio`, `image`, `video`, and `pdf`; the undeclared side defaults to `["text"]`, but a declared side that contains no supported values makes the whole declaration untrustworthy and the existing configuration is left untouched
 - `supports_vision: true` without `modalities` falls back to input `["text", "image"]`
 - `supports_reasoning` enables `reasoning`
 - `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`: `low`, `medium`, and `high` are kept unless the matching flag is explicitly `false`, while `none`, `minimal`, `xhigh`, and `max` require the flag to be `true`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,8 +368,10 @@ Set `modelInfoFormat` to `"litellm"` to enable it. The plugin requests `/v1/mode
 When model info is available, the plugin uses LiteLLM `model_info` fields to populate OpenCode model configuration:
 
 - `max_input_tokens`, `max_output_tokens`, and `max_tokens` become `limit.context`, `limit.input`, and `limit.output`
+- `modalities.input` and `modalities.output` become `modalities`, normalized to lowercase (`speech` becomes `audio`) and limited to `text`, `audio`, `image`, `video`, and `pdf`; the undeclared side defaults to `["text"]`
+- `supports_vision: true` without `modalities` falls back to input `["text", "image"]`
 - `supports_reasoning` enables `reasoning`
-- `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`
+- `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`: `low`, `medium`, and `high` are kept unless the matching flag is explicitly `false`, while `none`, `minimal`, `xhigh`, and `max` require the flag to be `true`
 - By default, entries whose `model_info.mode` is not `chat` are skipped
 
 ### vLLM Model Info

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,11 @@ export interface LiteLLMModelInfo {
   supports_xhigh_reasoning_effort?: boolean | null
   supports_max_reasoning_effort?: boolean | null
   supported_openai_params?: string[] | null
+  supports_vision?: boolean | null
+  modalities?: {
+    input?: string[] | null
+    output?: string[] | null
+  } | null
 }
 
 export interface LiteLLMModelInfoEntry {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,8 @@ export interface LiteLLMModelInfo {
   supports_none_reasoning_effort?: boolean | null
   supports_minimal_reasoning_effort?: boolean | null
   supports_low_reasoning_effort?: boolean | null
+  supports_medium_reasoning_effort?: boolean | null
+  supports_high_reasoning_effort?: boolean | null
   supports_xhigh_reasoning_effort?: boolean | null
   supports_max_reasoning_effort?: boolean | null
   supported_openai_params?: string[] | null

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -70,9 +70,34 @@ function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | 
   return Object.keys(variants).length > 0 ? variants : undefined
 }
 
+function toStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.length > 0) : undefined
+}
+
+function buildModalities(info: LiteLLMModelInfo): { input: string[]; output: string[] } | undefined {
+  const input = toStringArray(info.modalities?.input)
+  const output = toStringArray(info.modalities?.output)
+  if (input?.length || output?.length) {
+    return {
+      input: input?.length ? input : ['text'],
+      output: output?.length ? output : ['text'],
+    }
+  }
+  // Older LiteLLM deployments do not expose modalities; derive image input from supports_vision.
+  if (info.supports_vision === true) {
+    return { input: ['text', 'image'], output: ['text'] }
+  }
+  return undefined
+}
+
 function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
   const info = entry?.model_info
   if (!info) return
+
+  const modalities = buildModalities(info)
+  if (modalities) {
+    modelConfig.modalities = modalities
+  }
 
   const contextLimit = hasUsableNumber(info.max_input_tokens) ? info.max_input_tokens : info.max_tokens
   const outputLimit = hasUsableNumber(info.max_output_tokens) ? info.max_output_tokens : info.max_tokens

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -85,11 +85,14 @@ function getModalities(value: unknown): string[] | undefined {
 function buildModalities(info: LiteLLMModelInfo): { input: string[]; output: string[] } | undefined {
   const input = getModalities(info.modalities?.input)
   const output = getModalities(info.modalities?.output)
-  if (input?.length || output?.length) {
-    return {
-      input: input?.length ? input : ['text'],
-      output: output?.length ? output : ['text'],
-    }
+  const inputDeclared = Array.isArray(info.modalities?.input)
+  const outputDeclared = Array.isArray(info.modalities?.output)
+
+  // A declared side that normalizes to nothing leaves no trustworthy signal: treat the whole
+  // declaration as absent instead of inferring a modality the provider never confirmed.
+  if ((inputDeclared && input === undefined) || (outputDeclared && output === undefined)) return undefined
+  if (input || output) {
+    return { input: input ?? ['text'], output: output ?? ['text'] }
   }
   // Older LiteLLM deployments do not expose modalities; derive image input from supports_vision.
   if (info.supports_vision === true) {

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -61,8 +61,8 @@ function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | 
 
   // LiteLLM does not always expose per-tier flags for widely supported efforts.
   if (info.supports_low_reasoning_effort !== false) variants.low = { reasoningEffort: 'low' }
-  variants.medium = { reasoningEffort: 'medium' }
-  variants.high = { reasoningEffort: 'high' }
+  if (info.supports_medium_reasoning_effort !== false) variants.medium = { reasoningEffort: 'medium' }
+  if (info.supports_high_reasoning_effort !== false) variants.high = { reasoningEffort: 'high' }
 
   if (info.supports_xhigh_reasoning_effort === true) variants.xhigh = { reasoningEffort: 'xhigh' }
   if (info.supports_max_reasoning_effort === true) variants.max = { reasoningEffort: 'max' }

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -70,13 +70,21 @@ function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | 
   return Object.keys(variants).length > 0 ? variants : undefined
 }
 
-function toStringArray(value: unknown): string[] | undefined {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.length > 0) : undefined
+function getModalities(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const supportedModalities = new Set(['text', 'audio', 'image', 'video', 'pdf'])
+  const modalities = [...new Set(value
+    .filter((item): item is string => typeof item === 'string')
+    .map(item => item.trim().toLowerCase())
+    .map(item => item === 'speech' ? 'audio' : item)
+    .filter(item => supportedModalities.has(item)))]
+  return modalities.length > 0 ? modalities : undefined
 }
 
 function buildModalities(info: LiteLLMModelInfo): { input: string[]; output: string[] } | undefined {
-  const input = toStringArray(info.modalities?.input)
-  const output = toStringArray(info.modalities?.output)
+  const input = getModalities(info.modalities?.input)
+  const output = getModalities(info.modalities?.output)
   if (input?.length || output?.length) {
     return {
       input: input?.length ? input : ['text'],

--- a/test/litellm-model-info.test.ts
+++ b/test/litellm-model-info.test.ts
@@ -49,6 +49,28 @@ describe('LiteLLM model info enricher', () => {
     expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
   })
 
+  it('normalizes modality spellings, maps speech to audio, and drops duplicates', () => {
+    const enricher = litellmEnricher({
+      modalities: { input: ['TEXT', 'speech', ' image ', 'Text'], output: ['Text'] },
+    })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'audio', 'image'], output: ['text'] })
+  })
+
+  it('drops modalities outside the supported set, defaulting an emptied side to ["text"]', () => {
+    const enricher = litellmEnricher({
+      modalities: { input: ['text', 'hologram'], output: ['hologram'] },
+    })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['text'] })
+  })
+
   it('leaves existing modalities untouched when info carries no modality signals', () => {
     const enricher = litellmEnricher({ max_tokens: 8192 })
     expect(enricher).toBeDefined()

--- a/test/litellm-model-info.test.ts
+++ b/test/litellm-model-info.test.ts
@@ -57,4 +57,41 @@ describe('LiteLLM model info enricher', () => {
     enricher!.applyModelInfo(modelConfig, 'test-model')
     expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['text'] })
   })
+
+  describe('reasoning variants', () => {
+    function variantKeys(modelInfo: Record<string, unknown>): string[] {
+      const enricher = litellmEnricher({
+        supports_reasoning: true,
+        supported_openai_params: ['reasoning_effort'],
+        ...modelInfo,
+      })
+      const modelConfig: any = { id: 'test-model' }
+      enricher!.applyModelInfo(modelConfig, 'test-model')
+      return Object.keys(modelConfig.variants ?? {})
+    }
+
+    it('hides high when supports_high_reasoning_effort is false', () => {
+      expect(variantKeys({ supports_high_reasoning_effort: false })).toEqual(['low', 'medium'])
+    })
+
+    it('hides medium when supports_medium_reasoning_effort is false', () => {
+      expect(variantKeys({ supports_medium_reasoning_effort: false })).toEqual(['low', 'high'])
+    })
+
+    it('keeps medium and high when their flags are absent', () => {
+      expect(variantKeys({})).toEqual(['low', 'medium', 'high'])
+    })
+
+    it('honors all seven per-tier effort flags when set explicitly', () => {
+      expect(variantKeys({
+        supports_none_reasoning_effort: true,
+        supports_minimal_reasoning_effort: true,
+        supports_low_reasoning_effort: true,
+        supports_medium_reasoning_effort: true,
+        supports_high_reasoning_effort: true,
+        supports_xhigh_reasoning_effort: true,
+        supports_max_reasoning_effort: true,
+      })).toEqual(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+    })
+  })
 })

--- a/test/litellm-model-info.test.ts
+++ b/test/litellm-model-info.test.ts
@@ -60,15 +60,35 @@ describe('LiteLLM model info enricher', () => {
     expect(modelConfig.modalities).toEqual({ input: ['text', 'audio', 'image'], output: ['text'] })
   })
 
-  it('drops modalities outside the supported set, defaulting an emptied side to ["text"]', () => {
+  it('ignores the whole modalities declaration when a declared side holds only unsupported values', () => {
     const enricher = litellmEnricher({
       modalities: { input: ['text', 'hologram'], output: ['hologram'] },
     })
     expect(enricher).toBeDefined()
 
-    const modelConfig: any = { id: 'test-model' }
+    const modelConfig: any = { id: 'test-model', modalities: { input: ['text'], output: ['audio'] } }
     enricher!.applyModelInfo(modelConfig, 'test-model')
-    expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['text'] })
+    expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['audio'] })
+  })
+
+  it('preserves existing modalities when both declared sides are fully invalid', () => {
+    const enricher = litellmEnricher({
+      modalities: { input: ['hologram'], output: [42, ''] },
+    })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model', modalities: { input: ['text'], output: ['audio'] } }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['audio'] })
+  })
+
+  it('does not overwrite existing modalities when supports_vision is false', () => {
+    const enricher = litellmEnricher({ supports_vision: false })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model', modalities: { input: ['text', 'image'], output: ['text'] } }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
   })
 
   it('leaves existing modalities untouched when info carries no modality signals', () => {

--- a/test/litellm-model-info.test.ts
+++ b/test/litellm-model-info.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+
+function litellmEnricher(modelInfo: Record<string, unknown>) {
+  return createModelInfoEnricher(ModelInfoFormat.LiteLLM, {
+    data: [{ model_name: 'test-model', model_info: modelInfo }],
+  })
+}
+
+describe('LiteLLM model info enricher', () => {
+  it('sets modalities from model_info.modalities', () => {
+    const enricher = litellmEnricher({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+    })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+  })
+
+  it('derives image input from supports_vision when modalities are absent', () => {
+    const enricher = litellmEnricher({ supports_vision: true })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+  })
+
+  it('defaults a missing modality side to ["text"] when only one side is provided', () => {
+    const enricher = litellmEnricher({ modalities: { input: ['text', 'image'] } })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+  })
+
+  it('ignores non-string entries in modalities lists', () => {
+    const enricher = litellmEnricher({
+      modalities: { input: ['text', 'image', 42, null], output: ['text'] },
+    })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model' }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text', 'image'], output: ['text'] })
+  })
+
+  it('leaves existing modalities untouched when info carries no modality signals', () => {
+    const enricher = litellmEnricher({ max_tokens: 8192 })
+    expect(enricher).toBeDefined()
+
+    const modelConfig: any = { id: 'test-model', modalities: { input: ['text'], output: ['text'] } }
+    enricher!.applyModelInfo(modelConfig, 'test-model')
+    expect(modelConfig.modalities).toEqual({ input: ['text'], output: ['text'] })
+  })
+})


### PR DESCRIPTION
## What

LiteLLM gateways already publish the data needed to fill OpenCode model `modalities` and to gate reasoning-effort variants, but the `modelInfoFormat: "litellm"` enricher ignored both. This PR maps them:

- **`model_info.modalities.{input,output}` → `modalities`** — normalized to lowercase, `speech` → `audio`, deduplicated, and limited to OpenCode's supported set (`text`, `audio`, `image`, `video`, `pdf`), mirroring the normalization in `omniroute.ts`/`bifrost.ts`; non-string entries are dropped. When only one side is *declared* the other defaults to `["text"]`. When a **declared** side contains no usable values (all entries unsupported or malformed), the whole declaration is treated as no trustworthy signal and the enricher is a no-op — existing configuration is preserved rather than inferring a modality the provider never confirmed.
- **`model_info.supports_vision: true` → input `["text", "image"]`** — only when no `modalities` are declared. `false`/absent leaves config untouched (no fabricated restrictions).
- **`supports_medium/high_reasoning_effort`** now gate the `medium`/`high` reasoning variants: a variant is only dropped when the gateway explicitly declares the flag `false`. Absent/null keeps the current unconditional behavior — the existing comment ("LiteLLM does not always expose per-tier flags for widely supported efforts") is honored, not overwritten.

Every mapping is tri-state: absent data never clobbers user config, so gateways without these fields behave exactly as before.

## Evidence from a live gateway (`/v1/model/info`, 131 deployments)

| field | deployments |
|---|---|
| `modalities` (declared input/output lists) | 17 |
| `supports_vision: true` / `false` | 57 / 2 |
| `supports_medium_reasoning_effort` `true` / `false` | 13 / 3 |
| `supports_high_reasoning_effort` `true` / `false` | 11 / 11 |

Two deployments request `medium`/`high` variants that the gateway rejects with HTTP 400 (`supported_openai_params` lists `reasoning_effort`, but the per-tier flag is explicitly `false`) — the case this gating fixes.

Note on provenance: `modalities` and the per-tier effort flags are not fields of LiteLLM's static cost map; they are declared per deployment. LiteLLM's `ModelInfo` (`litellm/types/router.py`) is a pydantic model with `extra="allow"`, so such declared extras flow through `/v1/model/info` unmodified. On gateways that do not declare them, every code path in this PR is a no-op; `supports_vision` (a canonical cost-map field) still covers the vision case. Sanitized real response excerpts below.

<details>
<summary>Sanitized `/v1/model/info` entries (model names genericized; deployment ids, base URLs and key aliases removed; values real)</summary>

```json
{
  "data": [
    {
      "model_name": "chat-model-a",
      "litellm_params": { "model": "openai/chat-model-a" },
      "model_info": {
        "mode": "chat",
        "max_input_tokens": 200000,
        "max_output_tokens": 200000,
        "modalities": { "input": ["text", "image"], "output": ["text"] },
        "supports_vision": true,
        "supports_reasoning": true,
        "supports_none_reasoning_effort": true,
        "supports_minimal_reasoning_effort": false,
        "supports_low_reasoning_effort": true,
        "supports_medium_reasoning_effort": true,
        "supports_high_reasoning_effort": false,
        "supports_xhigh_reasoning_effort": true,
        "supports_max_reasoning_effort": false,
        "supported_openai_params": ["temperature", "top_p", "max_tokens", "tools", "tool_choice", "parallel_tool_calls", "response_format", "reasoning_effort"],
        "supports_function_calling": true,
        "input_cost_per_token": 0,
        "output_cost_per_token": 0,
        "cache_read_input_token_cost": 0,
        "cache_creation_input_token_cost": 0
      }
    },
    {
      "model_name": "reasoner-b",
      "litellm_params": { "model": "openai/reasoner-b" },
      "model_info": {
        "mode": "chat",
        "max_input_tokens": 200000,
        "supports_vision": true,
        "supports_reasoning": true,
        "supports_none_reasoning_effort": false,
        "supports_minimal_reasoning_effort": false,
        "supports_low_reasoning_effort": true,
        "supports_medium_reasoning_effort": false,
        "supports_high_reasoning_effort": true,
        "supports_xhigh_reasoning_effort": false,
        "supports_max_reasoning_effort": true,
        "supported_openai_params": ["reasoning_effort", "tools", "tool_choice", "response_format", "stop", "seed"],
        "supports_function_calling": true
      }
    }
  ]
}
```

</details>

## Review follow-ups

Follow-up commits add the modality normalization/whitelist that every merged mapper in this repo performs (lowercase, `speech` → `audio`, supported-set only) and, per review, the conservative unusable-declaration semantics above (declared-but-unusable side → enricher no-op, existing config preserved). All LiteLLM field mappings are documented in `docs/configuration.md`.

## Tests

13 tests in `test/litellm-model-info.test.ts` (written red against `dev` first): mapping, normalization/whitelist, non-string filtering, one-side default, unusable-declaration no-op (partial and fully invalid), vision fallback, `supports_vision: false` regression pin, no-signal no-clobber, and the variant gating (hide-on-`false`, keep-on-absent, all-seven flags). Full suite 143/143, `tsc --noEmit` clean.

## Relation to #82

Same files, disjoint fields. Merging both requires a trivial keep-both resolution in `src/types/index.ts` and `src/utils/model-info/litellm.ts` for whichever lands second.
