### PR TITLE
feat(litellm): map cost, tool_call and temperature from model_info

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,10 @@ When model info is available, the plugin uses LiteLLM `model_info` fields to pop
 - `max_input_tokens`, `max_output_tokens`, and `max_tokens` become `limit.context`, `limit.input`, and `limit.output`
 - `supports_reasoning` enables `reasoning`
 - `supports_*_reasoning_effort` and `supported_openai_params` create reasoning `variants`
+- `input_cost_per_token` and `output_cost_per_token` become `cost.input` and `cost.output` (per million tokens; only when both sides are present, explicit `0` is kept)
+- `cache_read_input_token_cost` and `cache_creation_input_token_cost` become `cost.cache_read` and `cost.cache_write` when positive
+- `supports_function_calling` becomes `tool_call` when it is a boolean
+- A non-empty `supported_openai_params` list determines `temperature` by whether it includes `"temperature"`
 - By default, entries whose `model_info.mode` is not `chat` are skipped
 
 ### vLLM Model Info

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,11 @@ export interface LiteLLMModelInfo {
   supports_xhigh_reasoning_effort?: boolean | null
   supports_max_reasoning_effort?: boolean | null
   supported_openai_params?: string[] | null
+  supports_function_calling?: boolean | null
+  input_cost_per_token?: number | null
+  output_cost_per_token?: number | null
+  cache_read_input_token_cost?: number | null
+  cache_creation_input_token_cost?: number | null
 }
 
 export interface LiteLLMModelInfoEntry {

--- a/src/utils/model-info/litellm.ts
+++ b/src/utils/model-info/litellm.ts
@@ -70,6 +70,36 @@ function createReasoningVariants(info: LiteLLMModelInfo): Record<string, any> | 
   return Object.keys(variants).length > 0 ? variants : undefined
 }
 
+// OpenCode config models price per million tokens (cost.cache_read / cache_write are flat keys);
+// LiteLLM reports per-token costs. Scaling happens inside the guard so an absurd per-token
+// value can never leak an Infinity into the persisted config.
+function nonNegativeCostPerMillion(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined
+  const perMillion = value * 1_000_000
+  return Number.isFinite(perMillion) ? perMillion : undefined
+}
+
+function positiveCostPerMillion(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined
+  const perMillion = value * 1_000_000
+  return Number.isFinite(perMillion) ? perMillion : undefined
+}
+
+function buildCost(info: LiteLLMModelInfo): Record<string, unknown> | undefined {
+  const input = nonNegativeCostPerMillion(info.input_cost_per_token)
+  const output = nonNegativeCostPerMillion(info.output_cost_per_token)
+  if (input === undefined || output === undefined) return undefined
+
+  const cacheRead = positiveCostPerMillion(info.cache_read_input_token_cost)
+  const cacheWrite = positiveCostPerMillion(info.cache_creation_input_token_cost)
+  return {
+    input,
+    output,
+    ...(cacheRead !== undefined ? { cache_read: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_write: cacheWrite } : {}),
+  }
+}
+
 function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | undefined): void {
   const info = entry?.model_info
   if (!info) return
@@ -91,6 +121,20 @@ function applyLiteLLMModelInfo(modelConfig: any, entry: LiteLLMModelInfoEntry | 
   const variants = createReasoningVariants(info)
   if (variants) {
     modelConfig.variants = variants
+  }
+
+  const cost = buildCost(info)
+  if (cost) {
+    modelConfig.cost = cost
+  }
+
+  if (typeof info.supports_function_calling === 'boolean') {
+    modelConfig.tool_call = info.supports_function_calling
+  }
+
+  // An empty list means "params undeclared", not "no params supported" — leave temperature alone.
+  if (Array.isArray(info.supported_openai_params) && info.supported_openai_params.length > 0) {
+    modelConfig.temperature = info.supported_openai_params.includes('temperature')
   }
 }
 

--- a/test/litellm-cost-and-capabilities.test.ts
+++ b/test/litellm-cost-and-capabilities.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { ModelInfoFormat } from '../src/types/plugin-config'
+import { createModelInfoEnricher } from '../src/utils/model-info'
+
+function enrich(modelInfo: Record<string, unknown>): any {
+  const enricher = createModelInfoEnricher(ModelInfoFormat.LiteLLM, {
+    data: [{ model_name: 'test-model', model_info: modelInfo }],
+  })
+  expect(enricher).toBeDefined()
+  const modelConfig: any = { id: 'test-model' }
+  enricher!.applyModelInfo(modelConfig, 'test-model')
+  return modelConfig
+}
+
+describe('LiteLLM cost, tool_call and temperature enrichment', () => {
+  it('maps per-token costs to per-million tokens', () => {
+    expect(enrich({ input_cost_per_token: 1e-6, output_cost_per_token: 2.5e-6 }).cost).toEqual({
+      input: 1,
+      output: 2.5,
+    })
+  })
+
+  it('keeps explicit zero costs as free', () => {
+    expect(enrich({ input_cost_per_token: 0, output_cost_per_token: 0 }).cost).toEqual({
+      input: 0,
+      output: 0,
+    })
+  })
+
+  it('includes flat cache_read and cache_write costs when positive', () => {
+    const config = enrich({
+      input_cost_per_token: 5e-7,
+      output_cost_per_token: 1.5e-6,
+      cache_read_input_token_cost: 1.25e-7,
+      cache_creation_input_token_cost: 2.5e-7,
+    })
+    expect(config.cost).toEqual({
+      input: 0.5,
+      output: 1.5,
+      cache_read: 0.125,
+      cache_write: 0.25,
+    })
+  })
+
+  it('omits cache keys when cache costs are null or zero', () => {
+    const config = enrich({
+      input_cost_per_token: 1e-6,
+      output_cost_per_token: 1e-6,
+      cache_read_input_token_cost: 0,
+      cache_creation_input_token_cost: null,
+    })
+    expect(config.cost).toEqual({ input: 1, output: 1 })
+  })
+
+  it('does not set cost when only one side is known', () => {
+    expect(enrich({ input_cost_per_token: 1e-6, output_cost_per_token: null }).cost).toBeUndefined()
+  })
+
+  it('does not set cost when scaling a per-token cost overflows to infinity', () => {
+    expect(enrich({ input_cost_per_token: 1e308, output_cost_per_token: 1e-6 }).cost).toBeUndefined()
+  })
+
+  it('ignores string prices; LiteLLM serializes numbers', () => {
+    expect(enrich({ input_cost_per_token: '1e-6', output_cost_per_token: '1e-6' }).cost).toBeUndefined()
+  })
+
+  it('sets tool_call from supports_function_calling', () => {
+    expect(enrich({ supports_function_calling: true }).tool_call).toBe(true)
+    expect(enrich({ supports_function_calling: false }).tool_call).toBe(false)
+  })
+
+  it('leaves tool_call untouched when the flag is null or missing', () => {
+    expect(enrich({ supports_function_calling: null }).tool_call).toBeUndefined()
+    expect(enrich({ max_tokens: 8192 }).tool_call).toBeUndefined()
+  })
+
+  it('sets temperature from supported_openai_params', () => {
+    expect(enrich({ supported_openai_params: ['tools', 'temperature'] }).temperature).toBe(true)
+    expect(enrich({ supported_openai_params: ['tools', 'response_format'] }).temperature).toBe(false)
+  })
+
+  it('leaves temperature untouched when supported_openai_params is missing', () => {
+    expect(enrich({ max_tokens: 8192 }).temperature).toBeUndefined()
+  })
+
+  it('leaves temperature untouched when supported_openai_params is an empty list', () => {
+    expect(enrich({ supported_openai_params: [] }).temperature).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

The `modelInfoFormat: "litellm"` enricher currently drops pricing and capability data that LiteLLM gateways publish for most deployments. This PR maps them onto OpenCode model config:

- **`input_cost_per_token` / `output_cost_per_token` → `cost.input` / `cost.output`** — multiplied by 1,000,000 (LiteLLM reports per-token costs; OpenCode config prices per million tokens; same convention as the `bifrost` enricher and models.dev). Cost is written only when **both** sides are valid non-negative numbers; an explicit `0` is preserved as "free". Scaling happens inside the finite guard so an absurd per-token value can never persist an `Infinity`.
- **`cache_read_input_token_cost` / `cache_creation_input_token_cost` → flat `cost.cache_read` / `cost.cache_write`** — written only when positive, matching the shape OpenCode's config consumer reads (`@opencode-ai/sdk` `ProviderConfig`: `cost?: { input, output, cache_read?, cache_write?, context_over_200k? }`; the nested `cache: { read, write }` shape exists only in opencode's resolved runtime token schema, not in config). LiteLLM emits `null`/`0` for cache costs on models without caching, so mapping them to absent (rather than "free caching") is the safe direction.
- **`supports_function_calling` → `tool_call`** when it is a boolean (precedent: `models-dev.ts`, `omniroute.ts`).
- **`supported_openai_params` → `temperature`** — `true`/`false` by membership, but only when the list is non-empty: an empty list means "params undeclared", not "nothing supported", so it must not actively suppress temperature.

Every mapping is tri-state; absent or malformed fields leave user config untouched. String-typed prices are intentionally not parsed (LiteLLM serializes Python numbers; unlike the bifrost upstream) — pinned by a test so the divergence is explicit.

## Evidence from a live gateway (`/v1/model/info`, 131 deployments)

| field | deployments with usable value |
|---|---|
| `input_cost_per_token` / `output_cost_per_token` > 0 | 78 / 78 |
| `cache_read_input_token_cost` > 0 | 31 |
| `cache_creation_input_token_cost` > 0 | 6 |
| `supports_function_calling` `true` / `false` | 92 / 0 |
| non-empty `supported_openai_params` | 124 |

All field names are canonical LiteLLM cost-map fields (`model_prices_and_context_window.json`, mirrored into `model_info` by `litellm/types/utils.py`) — not deployment extras. Sanitized real excerpts below (`cache-model-c` shows the cost/cache shape).

<details>
<summary>Sanitized `/v1/model/info` entries (model names genericized; deployment ids, base URLs and key aliases removed; values real)</summary>

```json
{
  "data": [
    {
      "model_name": "chat-model-a",
      "litellm_params": { "model": "openai/chat-model-a" },
      "model_info": {
        "mode": "chat",
        "max_input_tokens": 200000,
        "max_output_tokens": 200000,
        "modalities": { "input": ["text", "image"], "output": ["text"] },
        "supports_vision": true,
        "supports_reasoning": true,
        "supports_none_reasoning_effort": true,
        "supports_minimal_reasoning_effort": false,
        "supports_low_reasoning_effort": true,
        "supports_medium_reasoning_effort": true,
        "supports_high_reasoning_effort": false,
        "supports_xhigh_reasoning_effort": true,
        "supports_max_reasoning_effort": false,
        "supported_openai_params": ["temperature", "top_p", "max_tokens", "tools", "tool_choice", "parallel_tool_calls", "response_format", "reasoning_effort"],
        "supports_function_calling": true,
        "input_cost_per_token": 0,
        "output_cost_per_token": 0,
        "cache_read_input_token_cost": 0,
        "cache_creation_input_token_cost": 0
      }
    },
    {
      "model_name": "cache-model-c",
      "litellm_params": { "model": "openai/cache-model-c" },
      "model_info": {
        "mode": "chat",
        "max_input_tokens": 262144,
        "max_output_tokens": 262144,
        "input_cost_per_token": 0.0000015,
        "output_cost_per_token": 0.0000075,
        "cache_read_input_token_cost": 1.5e-7,
        "supports_vision": true,
        "supports_function_calling": true,
        "supports_reasoning": true,
        "supported_openai_params": ["stream", "temperature", "top_p", "max_tokens", "tools", "tool_choice", "seed", "stop", "response_format", "parallel_tool_calls"]
      }
    }
  ]
}
```

</details>

`supports_tool_choice` is deliberately not mapped: OpenCode has no corresponding config field.

## Field mapping documentation

`docs/configuration.md` lists every LiteLLM field the enricher consumes, including the cost/cache key shapes.

## Tests

12 tests in `test/litellm-cost-and-capabilities.test.ts` (written red against `dev` first): per-million scaling, both-sides rule, zero-as-free, flat cache keys, cache omission, overflow rejection, string-price rejection, `tool_call` boolean gate + tri-state, `temperature` membership, empty-list and absent-list no-ops. Full suite 142/142, `tsc --noEmit` clean.

## Relation to #81

Same files, disjoint fields (that PR touches modalities/variants, this one cost/tool_call/temperature). Merging both requires a trivial keep-both resolution in `src/types/index.ts` and `src/utils/model-info/litellm.ts` for whichever lands second.
