### PR TITLE
fix(package): ship compiled JS so Node-based hosts (OpenCode Desktop) can load the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ This can happen because OpenCode may continue using a previously cached package 
 
 After changing `opencode.json`, restart OpenCode. OpenCode loads config at startup, so command and provider changes are not guaranteed to take effect in an already-running session.
 
+OpenCode Desktop runs plugins in a plain Node runtime instead of Bun, and Node cannot load the raw TypeScript sources this package used to publish. The package now ships precompiled JavaScript (`dist/`) as its runtime entry, so Desktop hosts can load it. If the plugin never runs on Desktop, remove the stale cache directory (`~/.cache/opencode/packages/opencode-models-discovery@latest`) and restart, so the published build is reinstalled.
+
 ## `/connect` Support
 
 For custom OpenAI-compatible providers, you still define the provider in `opencode.json` so OpenCode and this plugin know the provider id, npm package, and `baseURL`.

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@opencode-ai/plugin": "^1.17.10",
         "@types/node": "^25.0.3",
         "@vitest/coverage-v8": "^4.0.16",
+        "esbuild": "^0.28.2",
         "eslint": "^9.39.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16",
@@ -38,6 +39,58 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.2", "", { "os": "android", "cpu": "arm" }, "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.2", "", { "os": "android", "cpu": "arm64" }, "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.2", "", { "os": "android", "cpu": "x64" }, "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.2", "", { "os": "linux", "cpu": "arm" }, "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.2", "", { "os": "linux", "cpu": "x64" }, "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.2", "", { "os": "none", "cpu": "x64" }, "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -196,6 +249,8 @@
     "effect": ["effect@4.0.0-beta.83", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@opencode-ai/plugin": "^1.17.10",
         "@types/node": "^25.0.3",
         "@vitest/coverage-v8": "^4.0.16",
+        "esbuild": "^0.28.2",
         "eslint": "^9.39.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16"
@@ -121,8 +122,451 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -803,7 +1247,6 @@
       "version": "25.5.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -812,7 +1255,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.3",
@@ -941,7 +1383,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1146,6 +1587,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "dev": true,
@@ -1161,7 +1644,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2122,7 +2604,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2413,7 +2894,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2490,7 +2970,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "version": "1.5.1",
   "description": "OpenCode plugin for auto-discovery of OpenAI-compatible models with dynamic provider configuration",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
   },
   "files": [
+    "dist",
     "src"
   ],
   "scripts": {
@@ -19,7 +24,8 @@
     "test:watch": "vitest watch",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "build": "npm run typecheck && npm run test:run",
+    "compile": "esbuild src/index.ts --bundle --format=esm --platform=node --packages=external --target=node18 --sourcemap --keep-names --outfile=dist/index.js",
+    "build": "npm run typecheck && npm run test:run && npm run compile",
     "validate": "npm run lint && npm run typecheck && npm run test:run",
     "validate:config": "bun scripts/validate-config.ts",
     "release": "bun scripts/release.ts",
@@ -55,6 +61,7 @@
     "@opencode-ai/plugin": "^1.17.10",
     "@types/node": "^25.0.3",
     "@vitest/coverage-v8": "^4.0.16",
+    "esbuild": "^0.28.2",
     "eslint": "^9.39.2",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"

--- a/test/node-loadable.test.ts
+++ b/test/node-loadable.test.ts
@@ -120,6 +120,12 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
       entry.endsWith('.js'),
       `runtime entry must be compiled JavaScript, got ${entry} (raw .ts cannot load under Node inside node_modules)`
     ).toBe(true)
+    if (stagedManifest.main) {
+      expect(
+        stagedManifest.main.endsWith('.js'),
+        `main must also be compiled JavaScript, got ${stagedManifest.main} (OpenCode Desktop's loader reads the main string directly, bypassing exports)`
+      ).toBe(true)
+    }
   })
 
   it('ships the declared entry inside the published tarball', () => {

--- a/test/node-loadable.test.ts
+++ b/test/node-loadable.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression tests for OpenCode Desktop plugin loading.
+ *
+ * The OpenCode Desktop app runs the server (and therefore plugins) inside
+ * Electron's plain Node runtime instead of Bun. Node refuses to type-strip
+ * `.ts` files located under `node_modules/`, and plugins are always installed
+ * under a `node_modules/` directory by the host. A published package whose
+ * entry point is raw TypeScript therefore loads in the CLI (Bun transpiles
+ * `.ts` everywhere) but fails silently in Desktop with
+ * `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` (see issue #65).
+ *
+ * These tests stage the package exactly as npm would publish it, install it
+ * into a simulated `node_modules/` tree, and import it with a plain `node`
+ * process - the same `await import(entry)` step the Desktop plugin loader
+ * performs.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const repoRoot = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..')
+
+function readPackageManifest(dir: string): {
+  name: string
+  main?: string
+  exports?: Record<string, unknown> | string
+} {
+  return JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf-8'))
+}
+
+/** Resolve the runtime entry file (not types) the way Node/Bun would. */
+function resolveEntryRelative(manifest: ReturnType<typeof readPackageManifest>): string {
+  const exp = manifest.exports
+  if (typeof exp === 'string') return exp
+  if (exp && typeof exp === 'object') {
+    const dot = (exp as Record<string, unknown>)['.']
+    if (typeof dot === 'string') return dot
+    if (dot && typeof dot === 'object') {
+      const conds = dot as Record<string, string>
+      // ignore the "types" condition: runtime resolution only
+      return conds['default'] ?? conds['import'] ?? conds['require'] ?? manifest.main ?? ''
+    }
+  }
+  return manifest.main ?? ''
+}
+
+function findNodeBinary(): string {
+  try {
+    execFileSync('node', ['--version'], { stdio: 'pipe' })
+    return 'node'
+  } catch {
+    throw new Error('plain `node` is required on PATH for the Desktop-compat import check')
+  }
+}
+
+describe('Node host compatibility (OpenCode Desktop)', () => {
+  const pkg = readPackageManifest(repoRoot)
+  let workDir: string
+  let stagedRoot: string
+  let stagedPkgDir: string
+
+  beforeAll(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), 'omd-node-loadable-'))
+    stagedRoot = path.join(workDir, 'consumer')
+    stagedPkgDir = path.join(stagedRoot, 'node_modules', pkg.name)
+    mkdirSync(stagedPkgDir, { recursive: true })
+
+    // Build the distributable first when the package declares how to.
+    const scripts = (readPackageManifest(repoRoot) as unknown as { scripts?: Record<string, string> }).scripts ?? {}
+    if (scripts['compile']) {
+      execFileSync('npm', ['run', 'compile'], { cwd: repoRoot, stdio: 'pipe' })
+    }
+
+    // Stage the package exactly as npm would publish it (respecting files/),
+    // without triggering lifecycle scripts.
+    execFileSync('npm', ['pack', '--pack-destination', workDir, '--ignore-scripts'], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    })
+    const tarball = readdirSync(workDir).find((f) => f.endsWith('.tgz'))
+    if (!tarball) throw new Error('npm pack produced no tarball')
+    execFileSync('tar', ['-xzf', path.join(workDir, tarball), '-C', stagedRoot], { stdio: 'pipe' })
+    rmSync(stagedPkgDir, { recursive: true, force: true })
+    execFileSync('mv', [path.join(stagedRoot, 'package'), stagedPkgDir], { stdio: 'pipe' })
+
+    // Provide the runtime dependency the host would install alongside the plugin.
+    const depSource = path.join(repoRoot, 'node_modules', 'xdg-basedir')
+    if (existsSync(depSource)) {
+      execFileSync('cp', ['-r', depSource, path.join(stagedRoot, 'node_modules', 'xdg-basedir')], { stdio: 'pipe' })
+    }
+  }, 60_000)
+
+  afterAll(() => {
+    if (workDir) rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it('declares a compiled JavaScript runtime entry point', () => {
+    const stagedManifest = readPackageManifest(stagedPkgDir)
+    const entry = resolveEntryRelative(stagedManifest)
+    expect(entry, 'package must declare main/exports for runtime resolution').toBeTruthy()
+    expect(
+      entry.endsWith('.js'),
+      `runtime entry must be compiled JavaScript, got ${entry} (raw .ts cannot load under Node inside node_modules)`
+    ).toBe(true)
+  })
+
+  it('ships the declared entry inside the published tarball', () => {
+    const entry = resolveEntryRelative(readPackageManifest(stagedPkgDir))
+    expect(existsSync(path.join(stagedPkgDir, entry)), `packaged entry missing: ${entry}`).toBe(true)
+  })
+
+  it('imports cleanly from plain Node inside a node_modules tree (Desktop loader parity)', () => {
+    const node = findNodeBinary()
+    const entry = resolveEntryRelative(readPackageManifest(stagedPkgDir))
+    const entryUrl = new URL(`file://${path.join(stagedPkgDir, entry)}`).href
+    const probe =
+      `const m = await import(${JSON.stringify(entryUrl)});` +
+      `const fn = m.ModelDiscoveryPlugin ?? m.default?.ModelDiscoveryPlugin ?? m.default;` +
+      `if (typeof fn !== 'function') { console.error('NO_PLUGIN_EXPORT'); process.exit(2); }`
+
+    let stdout = ''
+    let stderr = ''
+    let exitCode = 0
+    try {
+      stdout = execFileSync(node, ['--input-type=module', '-e', probe], {
+        cwd: stagedRoot,
+        stdio: 'pipe',
+        encoding: 'utf-8',
+      })
+    } catch (error) {
+      const e = error as { status?: number; stdout?: string; stderr?: string }
+      exitCode = e.status ?? 1
+      stdout = e.stdout ?? ''
+      stderr = e.stderr ?? ''
+    }
+    expect(
+      { exitCode, stderr: stderr.slice(0, 800) },
+      'plain Node (OpenCode Desktop runtime) must be able to import the published plugin entry'
+    ).toEqual({ exitCode: 0, stderr: '' })
+    expect(stdout).toBe('')
+  }, 30_000)
+})

--- a/test/node-loadable.test.ts
+++ b/test/node-loadable.test.ts
@@ -56,6 +56,20 @@ function findNodeBinary(): string {
   }
 }
 
+/**
+ * npm exports CLI flags as `npm_config_*` environment variables to lifecycle
+ * children, so this test can run nested inside `npm publish` (prepublishOnly)
+ * or `npm publish --dry-run`. Scrub inherited config so plain `npm pack` and
+ * `npm run compile` behave exactly as if invoked from a clean shell.
+ */
+function cleanNpmEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('npm_config_')) delete env[key]
+  }
+  return env
+}
+
 describe('Node host compatibility (OpenCode Desktop)', () => {
   const pkg = readPackageManifest(repoRoot)
   let workDir: string
@@ -71,7 +85,7 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
     // Build the distributable first when the package declares how to.
     const scripts = (readPackageManifest(repoRoot) as unknown as { scripts?: Record<string, string> }).scripts ?? {}
     if (scripts['compile']) {
-      execFileSync('npm', ['run', 'compile'], { cwd: repoRoot, stdio: 'pipe' })
+      execFileSync('npm', ['run', 'compile'], { cwd: repoRoot, stdio: 'pipe', env: cleanNpmEnv() })
     }
 
     // Stage the package exactly as npm would publish it (respecting files/),
@@ -79,6 +93,7 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
     execFileSync('npm', ['pack', '--pack-destination', workDir, '--ignore-scripts'], {
       cwd: repoRoot,
       stdio: 'pipe',
+      env: cleanNpmEnv(),
     })
     const tarball = readdirSync(workDir).find((f) => f.endsWith('.tgz'))
     if (!tarball) throw new Error('npm pack produced no tarball')

--- a/test/node-loadable.test.ts
+++ b/test/node-loadable.test.ts
@@ -10,12 +10,12 @@
  * `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` (see issue #65).
  *
  * These tests stage the package exactly as npm would publish it, install it
- * into a simulated `node_modules/` tree, and import it with a plain `node`
- * process - the same `await import(entry)` step the Desktop plugin loader
- * performs.
+ * into a simulated `node_modules/` tree, and import it BY PACKAGE NAME with a
+ * plain `node` process, so Node's own exports/main resolution runs - the same
+ * step the Desktop plugin loader performs.
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, renameSync, cpSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -99,12 +99,12 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
     if (!tarball) throw new Error('npm pack produced no tarball')
     execFileSync('tar', ['-xzf', path.join(workDir, tarball), '-C', stagedRoot], { stdio: 'pipe' })
     rmSync(stagedPkgDir, { recursive: true, force: true })
-    execFileSync('mv', [path.join(stagedRoot, 'package'), stagedPkgDir], { stdio: 'pipe' })
+    renameSync(path.join(stagedRoot, 'package'), stagedPkgDir)
 
     // Provide the runtime dependency the host would install alongside the plugin.
     const depSource = path.join(repoRoot, 'node_modules', 'xdg-basedir')
     if (existsSync(depSource)) {
-      execFileSync('cp', ['-r', depSource, path.join(stagedRoot, 'node_modules', 'xdg-basedir')], { stdio: 'pipe' })
+      cpSync(depSource, path.join(stagedRoot, 'node_modules', 'xdg-basedir'), { recursive: true })
     }
   }, 60_000)
 
@@ -129,22 +129,23 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
 
   it('imports cleanly from plain Node inside a node_modules tree (Desktop loader parity)', () => {
     const node = findNodeBinary()
-    const entry = resolveEntryRelative(readPackageManifest(stagedPkgDir))
-    const entryUrl = new URL(`file://${path.join(stagedPkgDir, entry)}`).href
-    const probe =
-      `const m = await import(${JSON.stringify(entryUrl)});` +
-      `const fn = m.ModelDiscoveryPlugin ?? m.default?.ModelDiscoveryPlugin ?? m.default;` +
-      `if (typeof fn !== 'function') { console.error('NO_PLUGIN_EXPORT'); process.exit(2); }`
+    // A bare-specifier dynamic import run by a real consumer script: Node's own
+    // resolution algorithm reads the staged package's exports/main exactly as the
+    // host loader does, so a manifest Node would reject cannot pass this test.
+    const probeFile = path.join(stagedRoot, 'desktop-loader-probe.mjs')
+    writeFileSync(
+      probeFile,
+      `const m = await import(${JSON.stringify(pkg.name)});\n` +
+        `const fn = m.ModelDiscoveryPlugin ?? m.default?.ModelDiscoveryPlugin ?? m.default;\n` +
+        `if (typeof fn !== 'function') { console.error('NO_PLUGIN_EXPORT'); process.exit(2); }\n` +
+        `console.log('DESKTOP_IMPORT_OK');\n`
+    )
 
     let stdout = ''
     let stderr = ''
     let exitCode = 0
     try {
-      stdout = execFileSync(node, ['--input-type=module', '-e', probe], {
-        cwd: stagedRoot,
-        stdio: 'pipe',
-        encoding: 'utf-8',
-      })
+      stdout = execFileSync(node, [probeFile], { cwd: stagedRoot, stdio: 'pipe', encoding: 'utf-8' })
     } catch (error) {
       const e = error as { status?: number; stdout?: string; stderr?: string }
       exitCode = e.status ?? 1
@@ -152,9 +153,8 @@ describe('Node host compatibility (OpenCode Desktop)', () => {
       stderr = e.stderr ?? ''
     }
     expect(
-      { exitCode, stderr: stderr.slice(0, 800) },
-      'plain Node (OpenCode Desktop runtime) must be able to import the published plugin entry'
-    ).toEqual({ exitCode: 0, stderr: '' })
-    expect(stdout).toBe('')
+      { exitCode, stdout: stdout.trim(), stderr: stderr.slice(0, 800) },
+      'plain Node (OpenCode Desktop runtime) must resolve the published manifest and import the plugin by package name'
+    ).toEqual({ exitCode: 0, stdout: 'DESKTOP_IMPORT_OK', stderr: '' })
   }, 30_000)
 })


### PR DESCRIPTION
## Problem

`opencode-models-discovery` loads in the OpenCode **CLI** but never executes in the OpenCode **Desktop** app (see #65), with no error in `opencode.log`.

This is reproducible and fixable on the plugin side.

### Root cause

The Desktop app embeds the opencode server in its **Electron (plain Node) main process** — there is no Bun (the plugin runtime input is literally `$: typeof Bun === "undefined" ? void 0 : Bun.$`). Its plugin loader resolves the package entry from `package.json` (`main`/`exports`) and runs a plain `await import(entry)` with no transpiler registered.

This package's published entry is raw TypeScript (`main: ./src/index.ts`). A plain Node runtime rejects it on three independent counts, each fatal:

| # | Blocker | Error |
|---|---|---|
| 1 | Type-stripping is disabled for files under `node_modules/` — and installed plugins always live under a `node_modules/` directory | `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` |
| 2 | `export enum ModelInfoFormat` — enums are not erasable TS syntax for `--experimental-strip-types` | `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` |
| 3 | extensionless / directory relative imports (`./plugin`) — valid only under Bun's resolver | `ERR_UNSUPPORTED_DIR_IMPORT` |

The loader reports failures via `publishPluginError`, which only emits a *session event* — it never reaches `opencode.log`. That is exactly why #65 saw the plugin "silently never run" with clean logs.

Everything else in `src/` is already runtime-agnostic (`node:fs`, `node:path`, `node:http`, `node:https`, `xdg-basedir`; zero Bun APIs), so shipping compiled JS makes the plugin work on Desktop without behavior changes on the CLI.

Related upstream context: [anomalyco/opencode#34553](https://github.com/anomalyco/opencode/issues/34553) documents the same CLI-Bun-vs-Desktop-Node gap for other plugins; #26085 (npm `@local` install failure) is a separate host bug and does **not** block this plugin — the `@opencode-ai/plugin` import is type-only and erased at compile time.

## Fix

Compile the entry to `dist/index.js` (esbuild, ESM, `platform=node`, `packages=external`, sourcemap) and point `main`/`exports.default` at it. `types` (and `exports.types`) still resolve to `src/index.ts`, `src/` is still shipped for source maps, so DX and editor types are unchanged.

- `compile` script runs `esbuild src/index.ts --bundle --format=esm --platform=node --packages=external --target=node18 --sourcemap --keep-names --outfile=dist/index.js`
- wired into `build` (and therefore `prepublishOnly` and `bun scripts/release.ts publish`), so no publish can ship without `dist/`
- `dist/` added to `files` (`dist/` is already in `.gitignore`)
- `esbuild` added as devDependency only; runtime dependency surface is unchanged (`xdg-basedir` stays external)

## Tests

New `test/node-loadable.test.ts` mirrors what the Desktop loader does: it runs `npm pack --ignore-scripts`, extracts the tarball into a simulated `node_modules/` tree, and imports the packaged entry from a **plain `node` process**, asserting a compiled-JS entry and a working import of `ModelDiscoveryPlugin`.

- **Red before this change**, with the exact production failure: `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING .../node_modules/opencode-models-discovery/src/index.ts`
- **Green after**: 133/133 tests pass, `tsc --noEmit` clean
- Extra manual verification of the packed tarball against the real Desktop runtime (Electron 42 / Node 24 via `ELECTRON_RUN_AS_NODE`) and against Bun (CLI host parity) — both import `ModelDiscoveryPlugin` successfully.

## Release note

Desktop users will still see the old broken copy until their OpenCode plugin cache refreshes; removing `~/.cache/opencode/packages/opencode-models-discovery@latest` (documented in the README note added here) forces the new build to install.

Closes #65
