### PR TITLE
docs: add an A2Agent model discovery configuration example

### DIFF
--- a/docs/config_example/README.md
+++ b/docs/config_example/README.md
@@ -16,6 +16,7 @@ Do not paste secrets into public issues or pull requests. Configure provider cre
 
 ## Examples
 
+- [A2Agent](a2agent.md)
 - [AI-ROUTER](ai-router.md)
 - [DeepSeek](deepseek.md)
 

--- a/docs/config_example/a2agent.md
+++ b/docs/config_example/a2agent.md
@@ -1,0 +1,38 @@
+# A2Agent Configuration Example
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or sponsored by
+[A2Agent](https://a2agent.me/).
+
+## Example
+
+```json
+{
+  "provider": {
+    "a2agent": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "A2Agent",
+      "options": {
+        "baseURL": "https://api.a2agent.me/v1",
+        "modelsDiscovery": {
+          "enabled": true
+        }
+      },
+      "models": {}
+    }
+  }
+}
+```
+
+## Notes
+
+- Configure credentials with OpenCode `/connect` when possible, or through
+  local private configuration.
+- This uses the plugin's standard `/v1/models` discovery path, which resolves
+  to `https://api.a2agent.me/v1/models`.
+- The example intentionally does not declare a static model list, filters,
+  pricing, or third-party metadata. Returned models depend on the account and
+  current API response.
+- Verify the current API base URL, model availability, pricing, terms of
+  service, data handling, and regional availability before use.


### PR DESCRIPTION
## Summary

This adds a narrowly scoped community configuration example for A2Agent using the plugin's existing OpenAI-compatible `/v1/models` discovery flow.

## Changes

- Adds one provider example under `docs/config_example/`
- Links the example from the community examples index
- Leaves the model list empty so it is populated dynamically
- Avoids static pricing, model metadata, credentials, or promotional claims
- Includes a clear non-affiliation disclaimer

## Validation

- `npm ci`: passed
- `npm run typecheck`: passed
- Configuration JSON extraction/parsing and discovery assertions: passed
- `npm run test:run`: 75 tests passed; 3 existing Windows-only path-separator assertions failed and are unrelated to this documentation-only change
- `npm run validate`: could not complete because the `community/config-examples` branch does not include the ESLint v9 configuration expected by the script

## Security

No API key, token, cookie, credential, model price, or private URL is included.

## Scope

The patch contains exactly one provider example and one index link, matching the contribution scope documented on the `community/config-examples` branch.